### PR TITLE
feat: support configuring database settings

### DIFF
--- a/docs/resources/settings.md
+++ b/docs/resources/settings.md
@@ -16,6 +16,10 @@ Settings resource
 resource "supabase_settings" "production" {
   project_ref = "mayuaycdtijbctgqbycg"
 
+  database = jsonencode({
+    statement_timeout = "10s"
+  })
+
   api = jsonencode({
     db_schema            = "public,storage,graphql_public"
     db_extra_search_path = "public,extensions"
@@ -39,7 +43,7 @@ resource "supabase_settings" "production" {
 
 - `api` (String) API settings as [serialised JSON](https://api.supabase.com/api/v1#/services/updatePostgRESTConfig)
 - `auth` (String) Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig)
-- `database` (String) Database settings as serialised JSON
+- `database` (String) Database settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateConfig)
 - `network` (String) Network settings as serialised JSON
 - `pooler` (String) Pooler settings as serialised JSON
 - `storage` (String) Storage settings as serialised JSON

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -175,7 +175,7 @@
               },
               "database": {
                 "type": "string",
-                "description": "Database settings as serialised JSON",
+                "description": "Database settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateConfig)",
                 "description_kind": "markdown",
                 "optional": true
               },

--- a/examples/resources/supabase_settings/resource.tf
+++ b/examples/resources/supabase_settings/resource.tf
@@ -1,6 +1,10 @@
 resource "supabase_settings" "production" {
   project_ref = "mayuaycdtijbctgqbycg"
 
+  database = jsonencode({
+    statement_timeout = "10s"
+  })
+
   api = jsonencode({
     db_schema            = "public,storage,graphql_public"
     db_extra_search_path = "public,extensions"

--- a/internal/provider/settings_resource.go
+++ b/internal/provider/settings_resource.go
@@ -279,20 +279,10 @@ func updateApiConfig(ctx context.Context, plan *SettingsResourceModel, client *a
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 
-	partial := make(map[string]interface{})
-	if diags := plan.Api.Unmarshal(&partial); diags.HasError() {
-		// Unreachable because unmarshalling to request body returned no error
-		return diags
-	}
-	pickConfig(*httpResp.JSON200, partial)
-
-	value, err := json.Marshal(partial)
-	if err != nil {
-		msg := fmt.Sprintf("Unable to update api settings, got marshal error: %s", err)
+	if plan.Api, err = parseConfig(plan.Api, *httpResp.JSON200); err != nil {
+		msg := fmt.Sprintf("Unable to update api settings, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-
-	plan.Api = jsontypes.NewNormalizedValue(string(value))
 	return nil
 }
 
@@ -334,20 +324,10 @@ func updateAuthConfig(ctx context.Context, plan *SettingsResourceModel, client *
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 
-	partial := make(map[string]interface{})
-	if diags := plan.Auth.Unmarshal(&partial); diags.HasError() {
-		// Unreachable because unmarshalling to request body returned no error
-		return diags
-	}
-	pickConfig(*httpResp.JSON200, partial)
-
-	value, err := json.Marshal(partial)
-	if err != nil {
-		msg := fmt.Sprintf("Unable to update auth settings, got marshal error: %s", err)
+	if plan.Auth, err = parseConfig(plan.Auth, *httpResp.JSON200); err != nil {
+		msg := fmt.Sprintf("Unable to update auth settings, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-
-	plan.Auth = jsontypes.NewNormalizedValue(string(value))
 	return nil
 }
 

--- a/internal/provider/settings_resource_test.go
+++ b/internal/provider/settings_resource_test.go
@@ -22,6 +22,18 @@ func TestAccSettingsResource(t *testing.T) {
 	defer gock.OffAll()
 	// Step 1: create
 	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("10s"),
+		})
+	gock.New("https://api.supabase.com").
+		Put("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("10s"),
+		})
+	gock.New("https://api.supabase.com").
 		Get("/v1/projects/mayuaycdtijbctgqbycg/postgrest").
 		Reply(http.StatusOK).
 		JSON(api.PostgrestConfigResponse{
@@ -51,6 +63,18 @@ func TestAccSettingsResource(t *testing.T) {
 		})
 	// Step 2: read
 	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("10s"),
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("10s"),
+		})
+	gock.New("https://api.supabase.com").
 		Get("/v1/projects/mayuaycdtijbctgqbycg/postgrest").
 		Reply(http.StatusOK).
 		JSON(api.PostgrestConfigResponse{
@@ -79,6 +103,24 @@ func TestAccSettingsResource(t *testing.T) {
 			SiteUrl: Ptr("http://localhost:3000"),
 		})
 	// Step 3: update
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("10s"),
+		})
+	gock.New("https://api.supabase.com").
+		Put("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("20s"),
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/config/database/postgres").
+		Reply(http.StatusOK).
+		JSON(api.PostgresConfigResponse{
+			StatementTimeout: Ptr("20s"),
+		})
 	gock.New("https://api.supabase.com").
 		Get("/v1/projects/mayuaycdtijbctgqbycg/postgrest").
 		Reply(http.StatusOK).
@@ -157,6 +199,10 @@ func TestAccSettingsResource(t *testing.T) {
 const testAccSettingsResourceConfig = `
 resource "supabase_settings" "production" {
   project_ref = "mayuaycdtijbctgqbycg"
+
+  database = jsonencode({
+    statement_timeout = "20s"
+  })
 
   api = jsonencode({
 	db_schema            = "public,storage,graphql_public"


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

```tf
resource "supabase_settings" "production" {
  project_ref = "mayuaycdtijbctgqbycg"

  database = jsonencode({
    statement_timeout = "10s"
  })
}
```

The database settings is special because the default values are automatically adjusted when you upgrade compute size. For this reason, the supabase api only returns the overrides instead of the full settings currently.

## Additional context

Add any other context or screenshots.
