### PR TITLE
doc: make sure the doc clearly states which ID should be passed on importing.

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -79,7 +79,7 @@ resource "supabase_project" "production" {
 
 Run `terraform -chdir=module apply`. Enter the ID of your Supabase project at the prompt. If your local TF state is empty, your project will be imported from remote rather than recreated.
 
-Alternatively, you may use the `terraform import ...` command without editing the resource file.
+Alternatively, you may use the `terraform import ...` command without editing the resource file, for example, `terraform import supabase_project.production abcdefghijklmnopqrst` will let Terraform import your existing project, where `abcdefghijklmnopqrst` is your project's `Reference ID`. After which, running `terraform plan -out plan.out` may help you verify that your infrastructure matches the configuration.
 
 ## Configuring a project
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -79,7 +79,7 @@ resource "supabase_project" "production" {
 
 Run `terraform -chdir=module apply`. Enter the ID of your Supabase project at the prompt. If your local TF state is empty, your project will be imported from remote rather than recreated.
 
-Alternatively, you may use the `terraform import ...` command without editing the resource file, for example, `terraform import supabase_project.production abcdefghijklmnopqrst` will let Terraform import your existing project, where `abcdefghijklmnopqrst` is your project's `Reference ID`. After which, running `terraform plan -out plan.out` may help you verify that your infrastructure matches the configuration.
+Alternatively, you may use the `terraform import ...` command without editing the resource file. For example, `terraform -chdir=module import supabase_project.production abcdefghijklmnopqrst` will let Terraform import your existing project with reference ID `abcdefghijklmnopqrst`. After import, you can run `terraform -chdir=module plan` to verify that your infrastructure matches the configuration.
 
 ## Configuring a project
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

This is a simple documentation update.

## What is the current behavior?

At the moment, we already have a live project running and would like to import its configuration into Terraform management. 

The problem we ran into the first time was that we used the wrong project id and Terraform still told us "Import successful!", which led to a problem later when we ran `terraform plan`. This change makes sure we tell users what should be run on the import step, since importing existing projects is a pretty common use case.

edited: we found that the code snippets under `examples/` had it explained better, but guess no harm to make the doc more clear? 😄 