### PR TITLE
fix: update types to match published API types

### DIFF
--- a/internal/provider/pooler_data_source_test.go
+++ b/internal/provider/pooler_data_source_test.go
@@ -24,8 +24,8 @@ func TestAccPoolerDataSource(t *testing.T) {
 		JSON([]api.SupavisorConfigResponse{{
 			DatabaseType:     api.PRIMARY,
 			ConnectionString: poolerUrl,
-			DefaultPoolSize:  Ptr(float32(15)),
-			MaxClientConn:    Ptr(float32(200)),
+			DefaultPoolSize:  Ptr(int(15)),
+			MaxClientConn:    Ptr(int(200)),
 			PoolMode:         api.SupavisorConfigResponsePoolModeTransaction,
 		}})
 	// Run test

--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -180,14 +180,14 @@ func (r *ProjectResource) ImportState(ctx context.Context, req resource.ImportSt
 }
 
 func createProject(ctx context.Context, data *ProjectResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
-	body := api.V1CreateProjectBody{
+	body := api.V1CreateProjectBodyDto{
 		OrganizationId: data.OrganizationId.ValueString(),
 		Name:           data.Name.ValueString(),
 		DbPass:         data.DatabasePassword.ValueString(),
-		Region:         api.V1CreateProjectBodyRegion(data.Region.ValueString()),
+		Region:         api.V1CreateProjectBodyDtoRegion(data.Region.ValueString()),
 	}
 	if !data.InstanceSize.IsNull() {
-		body.DesiredInstanceSize = Ptr(api.DesiredInstanceSize(data.InstanceSize.ValueString()))
+		body.DesiredInstanceSize = Ptr(api.V1CreateProjectBodyDtoDesiredInstanceSize(data.InstanceSize.ValueString()))
 	}
 
 	httpResp, err := client.V1CreateAProjectWithResponse(ctx, body)

--- a/internal/provider/settings_resource_test.go
+++ b/internal/provider/settings_resource_test.go
@@ -219,21 +219,21 @@ func TestAccSettingsResource(t *testing.T) {
 		Reply(http.StatusOK).
 		JSON(api.AuthConfigResponse{
 			SiteUrl: Ptr("http://localhost:3000"),
-			JwtExp:  Ptr(float32(3600)),
+			JwtExp:  Ptr(int(3600)),
 		})
 	gock.New("https://api.supabase.com").
 		Patch("/v1/projects/mayuaycdtijbctgqbycg/config/auth").
 		Reply(http.StatusOK).
 		JSON(api.AuthConfigResponse{
 			SiteUrl: Ptr("http://localhost:3000"),
-			JwtExp:  Ptr(float32(1800)),
+			JwtExp:  Ptr(int(1800)),
 		})
 	gock.New("https://api.supabase.com").
 		Get("/v1/projects/mayuaycdtijbctgqbycg/config/auth").
 		Reply(http.StatusOK).
 		JSON(api.AuthConfigResponse{
 			SiteUrl: Ptr("http://localhost:3000"),
-			JwtExp:  Ptr(float32(1800)),
+			JwtExp:  Ptr(int(1800)),
 		})
 	// Run test
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Merging https://github.com/supabase/terraform-provider-supabase/pull/210 meant there are mismatches in expected types.

## What is the new behavior?

Types match expected and go build works again


