### PR TITLE
chore: add setup-terraform step to workflows

### DIFF
--- a/.github/workflows/generate-json.yml
+++ b/.github/workflows/generate-json.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - uses: hashicorp/setup-terraform@v3
       - run: go generate ./...
       - name: git diff
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters:
   enable:
     - durationcheck
     - errcheck
-    - exportloopref
+    - copyloopvar
     - forcetypeassert
     - godot
     - gofmt
@@ -20,8 +20,8 @@ linters:
     - nilerr
     - predeclared
     - staticcheck
-    - tenv
+    - usetesting
     - unconvert
     - unparam
     - unused
-    - vet
+    - govet


### PR DESCRIPTION


## What kind of change does this PR introduce?

Bug fix in workflows

## What is the current behavior?

Workflows break on PRs because terraform isn't available

## What is the new behavior?

Workflows should work again

## Additional context

GHA now use Ubuntu 24.0 and do not ship with terraform in the image. This needs to be setup manually.

https://github.com/actions/runner-images/issues/10636

```
Terraform	latest available	-	Removed from the Ubuntu 24.04 image due to maintenance reasons.
```
