### PR TITLE
Add documentation around Environment Variable configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,3 +25,16 @@ provider "supabase" {
 
 - `access_token` (String, Sensitive) Supabase access token
 - `endpoint` (String) Supabase API endpoint
+
+## Authentication
+
+Credentials can be provided using the `SUPABASE_ACCESS_TOKEN` environment variable.
+
+For example:
+```tf
+provider "aws" {}
+```
+```shell
+% export SUPABASE_ACCESS_TOKEN="anaccesstoken"
+% terraform plan
+```


### PR DESCRIPTION
## What kind of change does this PR introduce?
Doc Update

## What is the current behavior?
This works for me with the following (abridged) terraform configuration:
```tf
terraform {
  required_providers {
    supabase = {
      source  = "supabase/supabase"
      version = "~> 1.0"
    }
  }
}
```
