### PR TITLE
chore: gitignore provider binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+terraform-provider-supabase
 
 website/vendor
 


### PR DESCRIPTION
Add the binary produced by `go build` to gitignore