### PR TITLE
feat: allow updating a project's instance size

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -21,10 +21,7 @@ resource "supabase_project" "test" {
   instance_size     = "micro"
 
   lifecycle {
-    ignore_changes = [
-      database_password,
-      instance_size,
-    ]
+    ignore_changes = [database_password]
   }
 }
 ```

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -138,7 +138,8 @@
                 "type": "string",
                 "description": "Desired instance size of the project",
                 "description_kind": "markdown",
-                "optional": true
+                "optional": true,
+                "computed": true
               },
               "name": {
                 "type": "string",

--- a/examples/resources/supabase_project/resource.tf
+++ b/examples/resources/supabase_project/resource.tf
@@ -6,9 +6,6 @@ resource "supabase_project" "test" {
   instance_size     = "micro"
 
   lifecycle {
-    ignore_changes = [
-      database_password,
-      instance_size,
-    ]
+    ignore_changes = [database_password]
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.24.0
 	github.com/hashicorp/terraform-plugin-framework v1.16.1
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
+	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.3

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/hashicorp/terraform-plugin-framework v1.16.1 h1:1+zwFm3MEqd/0K3YBB2v9
 github.com/hashicorp/terraform-plugin-framework v1.16.1/go.mod h1:0xFOxLy5lRzDTayc4dzK/FakIgBhNf/lC4499R9cV4Y=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0 h1:SJXL5FfJJm17554Kpt9jFXngdM6fXbnUnZ6iT2IeiYA=
 github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0/go.mod h1:p0phD0IYhsu9bR4+6OetVvvH59I6LwjXGnTVEr8ox6E=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0 h1:Zz3iGgzxe/1XBkooZCewS0nJAaCFPFPHdNJd8FgE4Ow=
+github.com/hashicorp/terraform-plugin-framework-validators v0.19.0/go.mod h1:GBKTNGbGVJohU03dZ7U8wHqc2zYnMUawgCN+gC0itLc=
 github.com/hashicorp/terraform-plugin-go v0.29.0 h1:1nXKl/nSpaYIUBU1IG/EsDOX0vv+9JxAltQyDMpq5mU=
 github.com/hashicorp/terraform-plugin-go v0.29.0/go.mod h1:vYZbIyvxyy0FWSmDHChCqKvI40cFTDGSb3D8D70i9GM=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,25 +26,136 @@ func TestAccProjectResource(t *testing.T) {
 			Name: "foo",
 		})
 	gock.New("https://api.supabase.com").
-		Get("/v1/projects").
+		Get("/v1/projects/mayuaycdtijbctgqbycg").
 		Reply(http.StatusOK).
-		JSON([]api.V1ProjectResponse{{
+		JSON(api.V1ProjectResponse{
 			Id:             "mayuaycdtijbctgqbycg",
 			Name:           "foo",
 			OrganizationId: "continued-brown-smelt",
 			Region:         "us-east-1",
-		}})
-	// Step 2: read
+		})
 	gock.New("https://api.supabase.com").
-		Get("/v1/projects").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/billing/addons").
 		Reply(http.StatusOK).
-		JSON([]api.V1ProjectResponse{{
+		JSON(map[string]any{
+			"selected_addons": []map[string]any{
+				{
+					"type": "compute_instance",
+					"variant": map[string]any{
+						"id":    api.ListProjectAddonsResponseAvailableAddonsVariantsId0CiMicro,
+						"name":  "Micro",
+						"price": map[string]any{},
+					},
+				},
+			},
+			"available_addons": []map[string]any{},
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg").
+		Reply(http.StatusOK).
+		JSON(api.V1ProjectResponse{
 			Id:             "mayuaycdtijbctgqbycg",
 			Name:           "foo",
 			OrganizationId: "continued-brown-smelt",
 			Region:         "us-east-1",
-		}})
-	// Step 3: delete
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/billing/addons").
+		Reply(http.StatusOK).
+		JSON(map[string]any{
+			"selected_addons": []map[string]any{
+				{
+					"type": "compute_instance",
+					"variant": map[string]any{
+						"id":    api.ListProjectAddonsResponseAvailableAddonsVariantsId0CiMicro,
+						"name":  "Micro",
+						"price": map[string]any{},
+					},
+				},
+			},
+			"available_addons": []map[string]any{},
+		})
+	// Step 2: update
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg").
+		Reply(http.StatusOK).
+		JSON(api.V1ProjectResponse{
+			Id:             "mayuaycdtijbctgqbycg",
+			Name:           "foo",
+			OrganizationId: "continued-brown-smelt",
+			Region:         "us-east-1",
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/billing/addons").
+		Reply(http.StatusOK).
+		JSON(map[string]any{
+			"selected_addons": []map[string]any{
+				{
+					"type": "compute_instance",
+					"variant": map[string]any{
+						"id":    api.ListProjectAddonsResponseAvailableAddonsVariantsId0Ci16xlarge,
+						"name":  "16XL",
+						"price": map[string]any{},
+					},
+				},
+			},
+			"available_addons": []map[string]any{},
+		})
+	gock.New("https://api.supabase.com").
+		Patch("/v1/projects/mayuaycdtijbctgqbycg/billing/addons").
+		Reply(http.StatusOK)
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg").
+		Reply(http.StatusOK).
+		JSON(api.V1ProjectResponse{
+			Id:             "mayuaycdtijbctgqbycg",
+			Name:           "foo",
+			OrganizationId: "continued-brown-smelt",
+			Region:         "us-east-1",
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/billing/addons").
+		Reply(http.StatusOK).
+		JSON(map[string]any{
+			"selected_addons": []map[string]any{
+				{
+					"type": "compute_instance",
+					"variant": map[string]any{
+						"id":    api.ListProjectAddonsResponseAvailableAddonsVariantsId0Ci16xlarge,
+						"name":  "16XL",
+						"price": map[string]any{},
+					},
+				},
+			},
+			"available_addons": []map[string]any{},
+		})
+	// Step 3: import state
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg").
+		Reply(http.StatusOK).
+		JSON(api.V1ProjectResponse{
+			Id:             "mayuaycdtijbctgqbycg",
+			Name:           "foo",
+			OrganizationId: "continued-brown-smelt",
+			Region:         "us-east-1",
+		})
+	gock.New("https://api.supabase.com").
+		Get("/v1/projects/mayuaycdtijbctgqbycg/billing/addons").
+		Reply(http.StatusOK).
+		JSON(map[string]any{
+			"selected_addons": []map[string]any{
+				{
+					"type": "compute_instance",
+					"variant": map[string]any{
+						"id":    api.ListProjectAddonsResponseAvailableAddonsVariantsId0Ci16xlarge,
+						"name":  "16XL",
+						"price": map[string]any{},
+					},
+				},
+			},
+			"available_addons": []map[string]any{},
+		})
+	// Step 4: delete
 	gock.New("https://api.supabase.com").
 		Delete("/v1/projects/mayuaycdtijbctgqbycg").
 		Reply(http.StatusOK).
@@ -64,12 +176,20 @@ func TestAccProjectResource(t *testing.T) {
 					resource.TestCheckResourceAttr("supabase_project.test", "id", "mayuaycdtijbctgqbycg"),
 				),
 			},
+			// Update testing
+			{
+				Config: strings.ReplaceAll(examples.ProjectResourceConfig, `"micro"`, `"16xlarge"`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_project.test", "id", "mayuaycdtijbctgqbycg"),
+					resource.TestCheckResourceAttr("supabase_project.test", "instance_size", "16xlarge"),
+				),
+			},
 			// ImportState testing
 			{
 				ResourceName:            "supabase_project.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"database_password", "instance_size"},
+				ImportStateVerifyIgnore: []string{"database_password"},
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Changing `instance_size` is not supported.
Attempting to do so results in the following error: `Update is not supported for project resource: <project>`

## What is the new behavior?

Plans like this are supported

```terraform
  ~ resource "supabase_project" "test" {
        id                = "xyz"
      ~ instance_size     = "micro" -> "small"
        name              = "test"
        # (3 unchanged attributes hidden)
    }
```

