### PR TITLE
feat: add import support with source download for edge functions

### DIFF
--- a/internal/provider/edge_function_resource.go
+++ b/internal/provider/edge_function_resource.go
@@ -10,15 +10,20 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
+	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/path"
+	tfpath "github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
@@ -52,7 +57,7 @@ func (m localChecksumPlanModifier) PlanModifyString(ctx context.Context, req pla
 	}
 
 	var entrypoint types.String
-	diags := req.Plan.GetAttribute(ctx, path.Root("entrypoint"), &entrypoint)
+	diags := req.Plan.GetAttribute(ctx, tfpath.Root("entrypoint"), &entrypoint)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -63,14 +68,14 @@ func (m localChecksumPlanModifier) PlanModifyString(ctx context.Context, req pla
 	}
 
 	var importMap types.String
-	diags = req.Plan.GetAttribute(ctx, path.Root("import_map"), &importMap)
+	diags = req.Plan.GetAttribute(ctx, tfpath.Root("import_map"), &importMap)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	var staticFiles types.List
-	diags = req.Plan.GetAttribute(ctx, path.Root("static_files"), &staticFiles)
+	diags = req.Plan.GetAttribute(ctx, tfpath.Root("static_files"), &staticFiles)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -121,6 +126,25 @@ type functionMetadata struct {
 	Name           string   `json:"name"`
 	ImportMapPath  *string  `json:"import_map_path,omitempty"`
 	StaticPatterns []string `json:"static_patterns,omitempty"`
+}
+
+type bundleMetadata struct {
+	EntrypointPath string `json:"deno2_entrypoint_path,omitempty"`
+}
+
+func getPartPath(header textproto.MIMEHeader) string {
+	if relPath := header.Get("Supabase-Path"); relPath != "" {
+		return relPath
+	}
+	cd := header.Get("Content-Disposition")
+	if cd == "" {
+		return ""
+	}
+	_, params, err := mime.ParseMediaType(cd)
+	if err != nil {
+		return ""
+	}
+	return params["filename"]
 }
 
 func (r *EdgeFunctionResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -320,22 +344,60 @@ func (r *EdgeFunctionResource) ImportState(ctx context.Context, req resource.Imp
 		Slug:       types.StringValue(slug),
 	}
 
-	found, diags := readEdgeFunction(ctx, &data, r.client)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
+	httpResp, err := r.client.V1GetAFunctionWithResponse(ctx, projectRef, slug)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read edge function, got error: %s", err))
 		return
 	}
 
-	if !found {
-		resp.Diagnostics.AddError(
-			"Resource Not Found",
-			fmt.Sprintf("Edge function %s/%s does not exist", projectRef, slug),
-		)
+	if httpResp.StatusCode() == http.StatusNotFound {
+		resp.Diagnostics.AddError("Resource Not Found",
+			fmt.Sprintf("Edge function %s/%s does not exist", projectRef, slug))
 		return
 	}
 
-	data.Entrypoint = types.StringNull()
-	data.ImportMap = types.StringNull()
+	if httpResp.JSON200 == nil {
+		resp.Diagnostics.AddError("Client Error",
+			fmt.Sprintf("Unable to read edge function, got status %d: %s", httpResp.StatusCode(), httpResp.Body))
+		return
+	}
+
+	result := httpResp.JSON200
+	data.Id = types.StringValue(result.Id)
+	data.Name = types.StringValue(result.Name)
+	data.Version = types.Int64Value(int64(result.Version))
+	data.Status = types.StringValue(string(result.Status))
+	if result.EzbrSha256 != nil {
+		data.Checksum = types.StringValue(*result.EzbrSha256)
+	} else {
+		data.Checksum = types.StringNull()
+	}
+	data.CreatedAt = types.Int64Value(result.CreatedAt)
+	data.UpdatedAt = types.Int64Value(result.UpdatedAt)
+
+	outputDir := filepath.Join(".", "supabase", "functions", slug)
+	downloadDiags := downloadFunctionSource(ctx, &data, outputDir, r.client, result.EntrypointPath, result.ImportMapPath)
+	if downloadDiags.HasError() {
+		detail := "unknown error"
+		for _, d := range downloadDiags {
+			if d.Severity() == diag.SeverityError {
+				detail = d.Detail()
+				break
+			}
+		}
+		resp.Diagnostics.Append(diag.NewWarningDiagnostic(
+			"Source Download Unavailable",
+			fmt.Sprintf("Could not download function source code: %s. "+
+				"Import succeeded with metadata only. "+
+				"Use 'supabase functions download' to obtain source files, then update your Terraform config.",
+				detail),
+		))
+		data.Entrypoint = types.StringNull()
+		data.ImportMap = types.StringNull()
+	}
+
+	// Cannot reconstruct from download
 	data.StaticFiles = types.ListNull(types.StringType)
 	data.LocalChecksum = types.StringNull()
 
@@ -509,7 +571,6 @@ func deployEdgeFunction(ctx context.Context, data *EdgeFunctionResourceModel, cl
 	return nil
 }
 
-// Returns (true, nil) if found, (false, nil) if not found (404), or (false, diags) on error.
 func readEdgeFunction(ctx context.Context, data *EdgeFunctionResourceModel, client *api.ClientWithResponses) (bool, diag.Diagnostics) {
 	projectRef := data.ProjectRef.ValueString()
 	slug := data.Slug.ValueString()
@@ -566,6 +627,209 @@ func deleteEdgeFunction(ctx context.Context, data *EdgeFunctionResourceModel, cl
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 
+	return nil
+}
+
+func downloadFunctionSource(ctx context.Context, data *EdgeFunctionResourceModel, outputDir string, client *api.ClientWithResponses, apiEntrypointPath, apiImportMapPath *string) diag.Diagnostics {
+	projectRef := data.ProjectRef.ValueString()
+	slug := data.Slug.ValueString()
+
+	httpResp, err := client.V1GetAFunctionBody(ctx, projectRef, slug, func(ctx context.Context, req *http.Request) error {
+		req.Header.Set("Accept", "multipart/form-data")
+		return nil
+	})
+	if err != nil {
+		msg := fmt.Sprintf("Unable to download function body, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(httpResp.Body, 4096))
+		msg := fmt.Sprintf("Unable to download function body, got status %d: %s", httpResp.StatusCode, string(body))
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+
+	mediaType, params, err := mime.ParseMediaType(httpResp.Header.Get("Content-Type"))
+	if err != nil {
+		msg := fmt.Sprintf("Unable to parse Content-Type, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		msg := fmt.Sprintf("Unable to download function body, expected multipart response got %s", mediaType)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+
+	mr := multipart.NewReader(httpResp.Body, params["boundary"])
+	form, err := mr.ReadForm(10 << 20)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read multipart form, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	defer func() {
+		_ = form.RemoveAll()
+	}()
+
+	meta := bundleMetadata{}
+	if metaParts, ok := form.Value["metadata"]; ok {
+		for _, part := range metaParts {
+			if err := json.Unmarshal([]byte(part), &meta); err != nil {
+				tflog.Warn(ctx, fmt.Sprintf("unable to parse bundle metadata: %s", err))
+			} else {
+				break
+			}
+		}
+	}
+
+	entrypointPath := meta.EntrypointPath
+
+	if entrypointPath == "" && apiEntrypointPath != nil && *apiEntrypointPath != "" {
+		parsed, err := url.Parse(*apiEntrypointPath)
+		if err == nil {
+			entrypointPath = parsed.Path
+		}
+	}
+
+	if entrypointPath == "" {
+		msg := "Unable to determine entrypoint path from bundle or API metadata"
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("using entrypoint path: %s", entrypointPath))
+
+	outAbs, err := filepath.Abs(outputDir)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to resolve output directory, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+
+	// Create temp dir in same parent (ensures same filesystem for os.Rename)
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		msg := fmt.Sprintf("Unable to create output directory, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	tempDir, err := os.MkdirTemp(filepath.Dir(outAbs), ".tf-import-*")
+	if err != nil {
+		msg := fmt.Sprintf("Unable to create temp directory, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	defer os.RemoveAll(tempDir)
+
+	type stagedFile struct {
+		tempPath  string
+		finalPath string
+	}
+	var staged []stagedFile
+
+	for _, fileHeaders := range form.File {
+		for _, fh := range fileHeaders {
+			partPath := getPartPath(fh.Header)
+			if partPath == "" {
+				tflog.Debug(ctx, fmt.Sprintf("skipping file with empty path: %s", fh.Filename))
+				continue
+			}
+
+			relPath, err := filepath.Rel(filepath.FromSlash(entrypointPath), filepath.FromSlash(partPath))
+			if err != nil {
+				tflog.Warn(ctx, fmt.Sprintf("filepath.Rel failed for %s: %s, using fallback", partPath, err))
+				relPath = filepath.FromSlash(path.Join("..", partPath))
+			}
+
+			finalDst := filepath.Join(outputDir, filepath.Base(filepath.FromSlash(entrypointPath)), relPath)
+
+			// Path traversal guard
+			destAbs, err := filepath.Abs(finalDst)
+			if err != nil {
+				msg := fmt.Sprintf("Unable to resolve path %s, got error: %s", finalDst, err)
+				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+			}
+			if destAbs != outAbs && !strings.HasPrefix(destAbs, outAbs+string(os.PathSeparator)) {
+				tflog.Info(ctx, fmt.Sprintf("skipping file outside output directory: bundle path %s resolved to %s (outside %s)", partPath, finalDst, outputDir))
+				continue
+			}
+
+			tempDst := filepath.Join(tempDir, filepath.Base(filepath.FromSlash(entrypointPath)), relPath)
+			if err := os.MkdirAll(filepath.Dir(tempDst), 0o755); err != nil {
+				msg := fmt.Sprintf("Unable to create temp directory %s, got error: %s", filepath.Dir(tempDst), err)
+				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+			}
+			src, err := fh.Open()
+			if err != nil {
+				msg := fmt.Sprintf("Unable to open multipart file %s, got error: %s", fh.Filename, err)
+				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+			}
+			dst, err := os.OpenFile(tempDst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
+			if err != nil {
+				src.Close()
+				msg := fmt.Sprintf("Unable to create temp file %s, got error: %s", tempDst, err)
+				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+			}
+			_, copyErr := io.Copy(dst, src)
+			src.Close()
+			closeErr := dst.Close()
+			if copyErr != nil {
+				msg := fmt.Sprintf("Unable to write temp file %s, got error: %s", tempDst, copyErr)
+				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+			}
+			if closeErr != nil {
+				msg := fmt.Sprintf("Unable to close temp file %s, got error: %s", tempDst, closeErr)
+				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+			}
+
+			staged = append(staged, stagedFile{tempPath: tempDst, finalPath: finalDst})
+		}
+	}
+
+	// Preflight collision check
+	for _, sf := range staged {
+		if _, err := os.Stat(sf.finalPath); err == nil {
+			msg := fmt.Sprintf("Unable to download function source, existing file would be overwritten: %s. "+
+				"Delete existing files or use 'supabase functions download' to refresh", sf.finalPath)
+			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+		}
+	}
+
+	// Move all files from temp to final destination
+	for _, sf := range staged {
+		if err := os.MkdirAll(filepath.Dir(sf.finalPath), 0o755); err != nil {
+			msg := fmt.Sprintf("Unable to create directory %s, got error: %s", filepath.Dir(sf.finalPath), err)
+			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+		}
+		if err := os.Rename(sf.tempPath, sf.finalPath); err != nil {
+			msg := fmt.Sprintf("Unable to move file to %s, got error: %s", sf.finalPath, err)
+			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+		}
+	}
+
+	// Set state fields
+	entrypointLocal := filepath.Join(outputDir, filepath.Base(filepath.FromSlash(entrypointPath)))
+	if _, err := os.Stat(entrypointLocal); err != nil {
+		msg := fmt.Sprintf("Unable to find entrypoint file after download %s, got error: %s", entrypointLocal, err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	data.Entrypoint = types.StringValue(entrypointLocal)
+
+	if apiImportMapPath != nil && *apiImportMapPath != "" {
+		parsed, err := url.Parse(*apiImportMapPath)
+		if err == nil && parsed.Path != "" {
+			importMapRelPath, relErr := filepath.Rel(filepath.FromSlash(entrypointPath), filepath.FromSlash(parsed.Path))
+			if relErr != nil {
+				importMapRelPath = filepath.FromSlash(path.Join("..", parsed.Path))
+			}
+			importMapLocal := filepath.Join(outputDir, filepath.Base(filepath.FromSlash(entrypointPath)), importMapRelPath)
+			if _, err := os.Stat(importMapLocal); err == nil {
+				data.ImportMap = types.StringValue(importMapLocal)
+			} else {
+				data.ImportMap = types.StringNull()
+			}
+		} else {
+			data.ImportMap = types.StringNull()
+		}
+	} else {
+		data.ImportMap = types.StringNull()
+	}
+
+	tflog.Info(ctx, fmt.Sprintf("downloaded function source to %s", outputDir))
 	return nil
 }
 

--- a/internal/provider/edge_function_resource.go
+++ b/internal/provider/edge_function_resource.go
@@ -711,29 +711,30 @@ func downloadFunctionSource(ctx context.Context, data *EdgeFunctionResourceModel
 
 	tflog.Debug(ctx, fmt.Sprintf("using entrypoint path: %s", entrypointPath))
 
-	outAbs, err := filepath.Abs(outputDir)
+	// Create parent of output dir (ensures same filesystem for os.Rename).
+	// outputDir itself is created by renaming tempDir into it.
+	if err := os.MkdirAll(filepath.Dir(outputDir), 0o755); err != nil {
+		msg := fmt.Sprintf("Unable to create output parent directory, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	absParentDir, err := filepath.Abs(filepath.Dir(outputDir))
 	if err != nil {
 		msg := fmt.Sprintf("Unable to resolve output directory, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-
-	// Create temp dir in same parent (ensures same filesystem for os.Rename)
-	if err := os.MkdirAll(outputDir, 0o755); err != nil {
-		msg := fmt.Sprintf("Unable to create output directory, got error: %s", err)
-		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
-	}
-	tempDir, err := os.MkdirTemp(filepath.Dir(outAbs), ".tf-import-*")
+	tempDir, err := os.MkdirTemp(absParentDir, ".tf-import-*")
 	if err != nil {
 		msg := fmt.Sprintf("Unable to create temp directory, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 	defer os.RemoveAll(tempDir)
 
-	type stagedFile struct {
-		tempPath  string
-		finalPath string
+	tempRoot, err := os.OpenRoot(tempDir)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to open temp directory root, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-	var staged []stagedFile
+	defer tempRoot.Close()
 
 	for _, fileHeaders := range form.File {
 		for _, fh := range fileHeaders {
@@ -749,24 +750,13 @@ func downloadFunctionSource(ctx context.Context, data *EdgeFunctionResourceModel
 				relPath = filepath.FromSlash(path.Join("..", partPath))
 			}
 
-			finalDst := filepath.Join(outputDir, entrypointBase, relPath)
-
-			// Path traversal guard
-			destAbs, err := filepath.Abs(finalDst)
-			if err != nil {
-				msg := fmt.Sprintf("Unable to resolve path %s, got error: %s", finalDst, err)
-				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
-			}
-			if destAbs != outAbs && !strings.HasPrefix(destAbs, outAbs+string(os.PathSeparator)) {
-				tflog.Info(ctx, fmt.Sprintf("skipping file outside output directory: bundle path %s resolved to %s (outside %s)", partPath, finalDst, outputDir))
+			tempRelPath := filepath.Join(entrypointBase, relPath)
+			if !filepath.IsLocal(tempRelPath) {
+				tflog.Info(ctx, fmt.Sprintf("skipping file outside output directory: bundle path %s resolved to %s", partPath, tempRelPath))
 				continue
 			}
-
-			// Runtime path traversal is guarded above (destAbs check on finalDst).
-			// tempDst writes to an ephemeral temp directory that is cleaned up by defer.
-			tempDst := filepath.Clean(filepath.Join(tempDir, entrypointBase, relPath))
-			if err := os.MkdirAll(filepath.Dir(tempDst), 0o755); err != nil { //nolint:gosec // G703: tempDst is bounded by tempDir; traversal guarded above
-				msg := fmt.Sprintf("Unable to create temp directory %s, got error: %s", filepath.Dir(tempDst), err)
+			if err := tempRoot.MkdirAll(filepath.Dir(tempRelPath), 0o755); err != nil {
+				msg := fmt.Sprintf("Unable to create temp directory for %s, got error: %s", tempRelPath, err)
 				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 			}
 			src, err := fh.Open()
@@ -774,52 +764,42 @@ func downloadFunctionSource(ctx context.Context, data *EdgeFunctionResourceModel
 				msg := fmt.Sprintf("Unable to open multipart file %s, got error: %s", fh.Filename, err)
 				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 			}
-			dst, err := os.OpenFile(tempDst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) //nolint:gosec // G703: tempDst is bounded by tempDir; traversal guarded above
+			dst, err := tempRoot.OpenFile(tempRelPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 			if err != nil {
 				src.Close()
-				msg := fmt.Sprintf("Unable to create temp file %s, got error: %s", tempDst, err)
+				msg := fmt.Sprintf("Unable to create temp file %s, got error: %s", tempRelPath, err)
 				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 			}
 			_, copyErr := io.Copy(dst, src)
 			src.Close()
 			closeErr := dst.Close()
 			if copyErr != nil {
-				msg := fmt.Sprintf("Unable to write temp file %s, got error: %s", tempDst, copyErr)
+				msg := fmt.Sprintf("Unable to write temp file %s, got error: %s", tempRelPath, copyErr)
 				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 			}
 			if closeErr != nil {
-				msg := fmt.Sprintf("Unable to close temp file %s, got error: %s", tempDst, closeErr)
+				msg := fmt.Sprintf("Unable to close temp file %s, got error: %s", tempRelPath, closeErr)
 				return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 			}
-
-			staged = append(staged, stagedFile{tempPath: tempDst, finalPath: finalDst})
 		}
 	}
 
-	// Preflight collision check
-	for _, sf := range staged {
-		if _, err := os.Stat(sf.finalPath); err == nil {
-			msg := fmt.Sprintf("Unable to download function source, existing file would be overwritten: %s. "+
-				"Delete existing files or use 'supabase functions download' to refresh", sf.finalPath)
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
-		}
+	// Preflight collision check — verify destination directory doesn't exist
+	if _, err := os.Stat(outputDir); err == nil {
+		msg := fmt.Sprintf("Unable to download function source, directory already exists: %s. "+
+			"Delete the directory or use 'supabase functions download' to refresh", outputDir)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 
-	// Move all files from temp to final destination
-	for _, sf := range staged {
-		if err := os.MkdirAll(filepath.Dir(sf.finalPath), 0o755); err != nil {
-			msg := fmt.Sprintf("Unable to create directory %s, got error: %s", filepath.Dir(sf.finalPath), err)
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
-		}
-		if err := os.Rename(sf.tempPath, sf.finalPath); err != nil {
-			msg := fmt.Sprintf("Unable to move file to %s, got error: %s", sf.finalPath, err)
-			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
-		}
+	// Move entire directory tree atomically from temp to final destination
+	if err := os.Rename(tempDir, outputDir); err != nil {
+		msg := fmt.Sprintf("Unable to move downloaded directory to %s, got error: %s", outputDir, err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 
 	// Set state fields
 	entrypointLocal := filepath.Clean(filepath.Join(outputDir, entrypointBase))
-	if info, err := os.Stat(entrypointLocal); err != nil { //nolint:gosec // G703: entrypointBase is validated (not ".", "..", or separator); outputDir is user-configured
+	if info, err := os.Stat(entrypointLocal); err != nil { //nolint:gosec // G703: read-only stat; entrypointBase is validated, outputDir is user-configured
 		msg := fmt.Sprintf("Unable to find entrypoint file after download %s, got error: %s", entrypointLocal, err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	} else if !info.Mode().IsRegular() {
@@ -836,7 +816,7 @@ func downloadFunctionSource(ctx context.Context, data *EdgeFunctionResourceModel
 				importMapRelPath = filepath.FromSlash(path.Join("..", parsed.Path))
 			}
 			importMapLocal := filepath.Clean(filepath.Join(outputDir, entrypointBase, importMapRelPath))
-			if _, err := os.Stat(importMapLocal); err == nil { //nolint:gosec // G703: importMapLocal is read-only stat check; components are validated
+			if _, err := os.Stat(importMapLocal); err == nil { //nolint:gosec // G703: read-only stat; components are validated
 				data.ImportMap = types.StringValue(importMapLocal)
 			} else {
 				data.ImportMap = types.StringNull()

--- a/internal/provider/edge_function_resource_test.go
+++ b/internal/provider/edge_function_resource_test.go
@@ -4,17 +4,63 @@
 package provider
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/supabase/cli/pkg/api"
 	"gopkg.in/h2non/gock.v1"
 )
+
+func mockMultipartBodyResponse(t *testing.T, projectRef, slug, entrypointPath string, files map[string]string) {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	headers := textproto.MIMEHeader{}
+	headers.Set("Content-Disposition", `form-data; name="metadata"`)
+	headers.Set("Content-Type", "application/json")
+	pw, err := writer.CreatePart(headers)
+	if err != nil {
+		t.Fatalf("Failed to create metadata part: %v", err)
+	}
+	meta := bundleMetadata{EntrypointPath: entrypointPath}
+	if err := json.NewEncoder(pw).Encode(meta); err != nil {
+		t.Fatalf("Failed to encode metadata: %v", err)
+	}
+
+	for filename, content := range files {
+		fh := textproto.MIMEHeader{}
+		fh.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, filename))
+		pw, err := writer.CreatePart(fh)
+		if err != nil {
+			t.Fatalf("Failed to create file part: %v", err)
+		}
+		if _, err := pw.Write([]byte(content)); err != nil {
+			t.Fatalf("Failed to write file content: %v", err)
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Failed to close multipart writer: %v", err)
+	}
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s/body", projectRef, slug)).
+		MatchHeader("Accept", "multipart/form-data").
+		Reply(http.StatusOK).
+		SetHeader("Content-Type", writer.FormDataContentType()).
+		Body(&buf)
+}
 
 func TestAccEdgeFunctionResource(t *testing.T) {
 	defer gock.OffAll()
@@ -359,6 +405,442 @@ resource "supabase_edge_function" "foo" {
 				ImportStateId:           fmt.Sprintf("%s/%s", projectRef, functionSlug),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"entrypoint", "import_map", "static_files", "local_checksum"},
+			},
+		},
+	})
+}
+
+func TestAccEdgeFunctionResource_ImportWithDownload(t *testing.T) {
+	defer gock.OffAll()
+
+	testFunctionID := uuid.New().String()
+	projectRef := "mayuaycdtijbctgqbycg"
+	functionSlug := "hello-world"
+	entrypointContent := `Deno.serve((req) => new Response("Hello from import"));`
+
+	// chdir to temp directory so downloaded files don't pollute the repo
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	entrypointPath := filepath.Join(tmpDir, "deploy-src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(entrypointPath), 0o755); err != nil {
+		t.Fatalf("Failed to create deploy-src dir: %v", err)
+	}
+	if err := os.WriteFile(entrypointPath, []byte(entrypointContent), 0o600); err != nil {
+		t.Fatalf("Failed to write entrypoint file: %v", err)
+	}
+
+	testConfig := fmt.Sprintf(`
+resource "supabase_edge_function" "test" {
+  project_ref = "%s"
+  slug        = "%s"
+  entrypoint  = "%s"
+}
+`, projectRef, functionSlug, entrypointPath)
+
+	createdAt := int64(1234567890)
+	updatedAt := int64(1234567890)
+	apiEntrypoint := "file:///src/index.ts"
+
+	gock.New("https://api.supabase.com").
+		Post(fmt.Sprintf("/v1/projects/%s/functions/deploy", projectRef)).
+		Reply(http.StatusCreated).
+		JSON(api.DeployFunctionResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.DeployFunctionResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	mockMultipartBodyResponse(t, projectRef, functionSlug, "/src/index.ts", map[string]string{
+		"/src/index.ts": entrypointContent,
+	})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	gock.New("https://api.supabase.com").
+		Delete(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK)
+
+	expectedEntrypoint := filepath.Join(".", "supabase", "functions", functionSlug, "index.ts")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_edge_function.test", "id", testFunctionID),
+				),
+			},
+			{
+				ResourceName:  "supabase_edge_function.test",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/%s", projectRef, functionSlug),
+				// Can't use ImportStateVerify because entrypoint path differs between
+				// deployed (absolute tmp path) and imported (relative ./supabase/functions/...)
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"entrypoint", "import_map", "static_files", "local_checksum"},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_edge_function.test", "entrypoint", expectedEntrypoint),
+					resource.TestCheckNoResourceAttr("supabase_edge_function.test", "import_map"),
+					// Verify file was actually written to disk
+					func(s *terraform.State) error {
+						content, err := os.ReadFile(expectedEntrypoint)
+						if err != nil {
+							return fmt.Errorf("expected entrypoint file at %s: %v", expectedEntrypoint, err)
+						}
+						if string(content) != entrypointContent {
+							return fmt.Errorf("entrypoint content mismatch: got %q, want %q", string(content), entrypointContent)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
+func TestAccEdgeFunctionResource_ImportFallback(t *testing.T) {
+	defer gock.OffAll()
+
+	testFunctionID := uuid.New().String()
+	projectRef := "mayuaycdtijbctgqbycg"
+	functionSlug := "fallback-func"
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	entrypointPath := filepath.Join(tmpDir, "deploy-src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(entrypointPath), 0o755); err != nil {
+		t.Fatalf("Failed to create deploy-src dir: %v", err)
+	}
+	if err := os.WriteFile(entrypointPath, []byte(`Deno.serve((req) => new Response("Hello"));`), 0o600); err != nil {
+		t.Fatalf("Failed to write entrypoint file: %v", err)
+	}
+
+	testConfig := fmt.Sprintf(`
+resource "supabase_edge_function" "fallback" {
+  project_ref = "%s"
+  slug        = "%s"
+  entrypoint  = "%s"
+}
+`, projectRef, functionSlug, entrypointPath)
+
+	createdAt := int64(1234567890)
+	updatedAt := int64(1234567890)
+
+	gock.New("https://api.supabase.com").
+		Post(fmt.Sprintf("/v1/projects/%s/functions/deploy", projectRef)).
+		Reply(http.StatusCreated).
+		JSON(api.DeployFunctionResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.DeployFunctionResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.FunctionSlugResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: 1234567890,
+			UpdatedAt: 1234567890,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.FunctionSlugResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: 1234567890,
+			UpdatedAt: 1234567890,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.FunctionSlugResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: 1234567890,
+			UpdatedAt: 1234567890,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s/body", projectRef, functionSlug)).
+		Reply(http.StatusInternalServerError).
+		BodyString("Internal Server Error")
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.FunctionSlugResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: 1234567890,
+			UpdatedAt: 1234567890,
+		})
+
+	gock.New("https://api.supabase.com").
+		Delete(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_edge_function.fallback", "id", testFunctionID),
+				),
+			},
+			{
+				ResourceName:            "supabase_edge_function.fallback",
+				ImportState:             true,
+				ImportStateId:           fmt.Sprintf("%s/%s", projectRef, functionSlug),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"entrypoint", "import_map", "static_files", "local_checksum"},
+			},
+		},
+	})
+}
+
+func TestAccEdgeFunctionResource_ImportWithExistingFiles(t *testing.T) {
+	defer gock.OffAll()
+
+	testFunctionID := uuid.New().String()
+	projectRef := "mayuaycdtijbctgqbycg"
+	functionSlug := "collision-func"
+	originalContent := "// original content - must not be overwritten"
+	downloadedContent := `Deno.serve((req) => new Response("Downloaded"));`
+
+	tmpDir := t.TempDir()
+	t.Chdir(tmpDir)
+
+	// Pre-create the output file to trigger collision detection
+	existingFile := filepath.Join(".", "supabase", "functions", functionSlug, "index.ts")
+	if err := os.MkdirAll(filepath.Dir(existingFile), 0o755); err != nil {
+		t.Fatalf("Failed to create output dir: %v", err)
+	}
+	if err := os.WriteFile(existingFile, []byte(originalContent), 0o600); err != nil {
+		t.Fatalf("Failed to write existing file: %v", err)
+	}
+
+	entrypointPath := filepath.Join(tmpDir, "deploy-src", "index.ts")
+	if err := os.MkdirAll(filepath.Dir(entrypointPath), 0o755); err != nil {
+		t.Fatalf("Failed to create deploy-src dir: %v", err)
+	}
+	if err := os.WriteFile(entrypointPath, []byte(downloadedContent), 0o600); err != nil {
+		t.Fatalf("Failed to write entrypoint file: %v", err)
+	}
+
+	testConfig := fmt.Sprintf(`
+resource "supabase_edge_function" "collision" {
+  project_ref = "%s"
+  slug        = "%s"
+  entrypoint  = "%s"
+}
+`, projectRef, functionSlug, entrypointPath)
+
+	createdAt := int64(1234567890)
+	updatedAt := int64(1234567890)
+	apiEntrypoint := "file:///src/index.ts"
+
+	gock.New("https://api.supabase.com").
+		Post(fmt.Sprintf("/v1/projects/%s/functions/deploy", projectRef)).
+		Reply(http.StatusCreated).
+		JSON(api.DeployFunctionResponse{
+			Id:        testFunctionID,
+			Slug:      functionSlug,
+			Name:      functionSlug,
+			Status:    api.DeployFunctionResponseStatusACTIVE,
+			Version:   1,
+			CreatedAt: &createdAt,
+			UpdatedAt: &updatedAt,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	mockMultipartBodyResponse(t, projectRef, functionSlug, "/src/index.ts", map[string]string{
+		"/src/index.ts": downloadedContent,
+	})
+
+	gock.New("https://api.supabase.com").
+		Get(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK).
+		JSON(api.FunctionSlugResponse{
+			Id:             testFunctionID,
+			Slug:           functionSlug,
+			Name:           functionSlug,
+			Status:         api.FunctionSlugResponseStatusACTIVE,
+			Version:        1,
+			CreatedAt:      1234567890,
+			UpdatedAt:      1234567890,
+			EntrypointPath: &apiEntrypoint,
+		})
+
+	gock.New("https://api.supabase.com").
+		Delete(fmt.Sprintf("/v1/projects/%s/functions/%s", projectRef, functionSlug)).
+		Reply(http.StatusOK)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_edge_function.collision", "id", testFunctionID),
+				),
+			},
+			{
+				ResourceName:            "supabase_edge_function.collision",
+				ImportState:             true,
+				ImportStateId:           fmt.Sprintf("%s/%s", projectRef, functionSlug),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"entrypoint", "import_map", "static_files", "local_checksum"},
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckNoResourceAttr("supabase_edge_function.collision", "entrypoint"),
+					func(s *terraform.State) error {
+						content, err := os.ReadFile(existingFile)
+						if err != nil {
+							return fmt.Errorf("existing file should still exist at %s: %v", existingFile, err)
+						}
+						if string(content) != originalContent {
+							return fmt.Errorf("existing file was modified: got %q, want %q", string(content), originalContent)
+						}
+						return nil
+					},
+					func(s *terraform.State) error {
+						parentDir := filepath.Join(".", "supabase", "functions")
+						matches, err := filepath.Glob(filepath.Join(parentDir, ".tf-import-*"))
+						if err != nil {
+							return fmt.Errorf("glob error: %v", err)
+						}
+						if len(matches) > 0 {
+							return fmt.Errorf("temp directory residue found: %v", matches)
+						}
+						return nil
+					},
+				),
 			},
 		},
 	})

--- a/internal/provider/edge_function_resource_test.go
+++ b/internal/provider/edge_function_resource_test.go
@@ -533,11 +533,9 @@ resource "supabase_edge_function" "test" {
 				),
 			},
 			{
-				ResourceName:  "supabase_edge_function.test",
-				ImportState:   true,
-				ImportStateId: fmt.Sprintf("%s/%s", projectRef, functionSlug),
-				// Can't use ImportStateVerify because entrypoint path differs between
-				// deployed (absolute tmp path) and imported (relative ./supabase/functions/...)
+				ResourceName:            "supabase_edge_function.test",
+				ImportState:             true,
+				ImportStateId:           fmt.Sprintf("%s/%s", projectRef, functionSlug),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"entrypoint", "import_map", "static_files", "local_checksum"},
 				Check: resource.ComposeAggregateTestCheckFunc(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`supabase_edge_function` supports `terraform import`, but did not safely/consistently materialize source into a local function directory for TER-4 scenarios.

## What is the new behavior?

`terraform import supabase_edge_function.<name> <project_ref>/<slug>` now:

  - Reads function metadata from API
  - Downloads function source via multipart body endpoint
  - Writes source to `./supabase/functions/<slug>/`
  - Sets entrypoint (and import_map when resolvable)
  - If source download fails, import still succeeds with metadata-only state and a warning
  - Staged writes to reduce partial-write risk
  - Collision preflight to avoid overwriting existing local files
  - Path traversal guard to skip out-of-bound paths

 ## Additional context

- `static_files` and `local_checksum` are null on import (not reconstructable from download source)
- Multipart/path handling follows Supabase CLI approach, provider adds extra safety checks for import

