### PR TITLE
feat: support importing API key by name

### DIFF
--- a/docs/resources/apikey.md
+++ b/docs/resources/apikey.md
@@ -52,11 +52,21 @@ Import is supported using the following syntax:
 The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
 
 ```shell
-# API keys can be imported using the project reference and the key's UUID,
+# API keys can be imported using the project reference and the key's name,
 # separated by a '/'.
 #
 # - project_ref: Found in the Supabase dashboard under Project Settings -> General,
 #   or in the project's URL: https://supabase.com/dashboard/project/<project_ref>
+# - api_key_name: Found in the Supabase dashboard under Project Settings -> API Keys.
+terraform import supabase_apikey.example <project_ref>/<api_key_name>
+
+# If multiple keys in the project share the same name, a type must also be provided.
+#
+# - api_key_type: The `type` of the target key (publishable or secret).
+terraform import supabase_apikey.example <project_ref>/<api_key_name>/<api_key_type>
+
+# Alternatively, the key's UUID can be used instead of its name.
+#
 # - api_key_id: The `id` field of the target key from the JSON output of:
 #     supabase projects api-keys --output json --project-ref <project_ref>
 terraform import supabase_apikey.example <project_ref>/<api_key_id>

--- a/examples/resources/supabase_apikey/import.sh
+++ b/examples/resources/supabase_apikey/import.sh
@@ -1,8 +1,18 @@
-# API keys can be imported using the project reference and the key's UUID,
+# API keys can be imported using the project reference and the key's name,
 # separated by a '/'.
 #
 # - project_ref: Found in the Supabase dashboard under Project Settings -> General,
 #   or in the project's URL: https://supabase.com/dashboard/project/<project_ref>
+# - api_key_name: Found in the Supabase dashboard under Project Settings -> API Keys.
+terraform import supabase_apikey.example <project_ref>/<api_key_name>
+
+# If multiple keys in the project share the same name, a type must also be provided.
+#
+# - api_key_type: The `type` of the target key (publishable or secret).
+terraform import supabase_apikey.example <project_ref>/<api_key_name>/<api_key_type>
+
+# Alternatively, the key's UUID can be used instead of its name.
+#
 # - api_key_id: The `id` field of the target key from the JSON output of:
 #     supabase projects api-keys --output json --project-ref <project_ref>
 terraform import supabase_apikey.example <project_ref>/<api_key_id>

--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -192,27 +192,151 @@ func (r *APIKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func (r *APIKeyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, "/")
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			`Expected import identifier in the format "project_ref/api_key_id".`,
-		)
+	projectRef, apiKeyID, diag := resolveAPIKeyImportID(ctx, r.client, req.ID)
+	if diag != nil {
+		resp.Diagnostics.Append(diag)
 		return
 	}
-
-	projectRef := strings.TrimSpace(parts[0])
-	apiKeyID := strings.TrimSpace(parts[1])
-	if projectRef == "" || apiKeyID == "" {
-		resp.Diagnostics.AddError(
-			"Unexpected Import Identifier",
-			"Both project_ref and api_key_id must be provided when importing. Example: myprojectref/3603c575-...",
-		)
-		return
-	}
-
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_ref"), types.StringValue(projectRef))...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(apiKeyID))...)
+}
+
+func resolveAPIKeyImportID(ctx context.Context, client *api.ClientWithResponses, importID string) (projectRef, apiKeyID string, _ diag.Diagnostic) {
+	parts := strings.Split(importID, "/")
+	switch len(parts) {
+	case 3:
+		projectRef, keyName, keyType := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), strings.TrimSpace(parts[2])
+		apiKeyID, diag := importAPIKeyByNameAndType(ctx, client, projectRef, keyName, keyType)
+		return projectRef, apiKeyID, diag
+	case 2:
+		projectRef, keyRef := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		apiKeyID, diag := importAPIKeyByNameOrID(ctx, client, projectRef, keyRef)
+		return projectRef, apiKeyID, diag
+	default:
+		return "", "", diag.NewErrorDiagnostic(
+			"Unexpected Import Identifier",
+			`This resource supports multiple identifier formats.
+
+Provide a project reference and the name of the API key.
+Example: myprojectref/myprojectkey
+
+If multiple keys in the project use the same name, a type of key to import must also be provided.
+Example: myprojectref/myprojectkey/publishable or myprojectref/myprojectkey/secret
+
+Alternatively, a project reference and a UUID of the API key can be used.
+Example: myprojectref/00000000-0000-0000-0000-000000000000`,
+		)
+	}
+}
+
+func importAPIKeyByNameOrID(ctx context.Context, client *api.ClientWithResponses, projectRef, keyRef string) (string, diag.Diagnostic) {
+	if projectRef == "" || keyRef == "" {
+		return "", diag.NewErrorDiagnostic(
+			"Unexpected Import Identifier",
+			`Both project_ref and api_key_name must be provided when importing.
+Example: myprojectref/myprojectkey
+
+Alternatively, a project_ref and api_key_id can be specified.
+Example: myprojectref/00000000-0000-0000-0000-000000000000`,
+		)
+	}
+
+	if uuid.Validate(keyRef) == nil {
+		return keyRef, nil
+	}
+
+	httpResp, err := client.V1GetProjectApiKeysWithResponse(ctx, projectRef, &api.V1GetProjectApiKeysParams{})
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read api keys, got error: %s", err)
+		return "", diag.NewErrorDiagnostic("Client Error", msg)
+	}
+	if httpResp.JSON200 == nil {
+		msg := fmt.Sprintf("Unable to read api keys, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
+		return "", diag.NewErrorDiagnostic("Client Error", msg)
+	}
+
+	foundKeyID := ""
+	keyRef = strings.ToLower(keyRef)
+	for _, val := range *httpResp.JSON200 {
+		if !val.Id.IsSpecified() || val.Id.IsNull() {
+			continue
+		}
+		if keyRef != val.Name {
+			continue
+		}
+
+		if foundKeyID != "" {
+			return "", diag.NewErrorDiagnostic(
+				"Ambiguous Import Identifier",
+				`Found multiple keys in the project that match the provided import identifier.
+Please use a more specific identifier like myprojectref/mykeyname/type or myprojectref/00000000-0000-0000-0000-000000000000`,
+			)
+		}
+
+		foundKeyID = val.Id.MustGet()
+	}
+
+	if foundKeyID == "" {
+		return "", diag.NewErrorDiagnostic(
+			"Import Error",
+			"Did not find a key matching the provided identifier.",
+		)
+	}
+
+	return foundKeyID, nil
+}
+
+func importAPIKeyByNameAndType(ctx context.Context, client *api.ClientWithResponses, projectRef, keyName, keyType string) (string, diag.Diagnostic) {
+	if projectRef == "" || keyName == "" || keyType == "" {
+		return "", diag.NewErrorDiagnostic(
+			"Unexpected Import Identifier",
+			"Both project_ref, api_key_name, and api_key_type must be provided when importing. Example: myprojectref/key-name/publishable",
+		)
+	}
+
+	apiKeyType := api.ApiKeyResponseType(keyType)
+	switch apiKeyType {
+	case api.ApiKeyResponseTypePublishable, api.ApiKeyResponseTypeSecret:
+	default:
+		return "", diag.NewErrorDiagnostic(
+			"Unexpected Import Identifier",
+			fmt.Sprintf("Unexpected API key type provided: `%s`. Must be either publishable or secret.", keyType),
+		)
+	}
+
+	httpResp, err := client.V1GetProjectApiKeysWithResponse(ctx, projectRef, &api.V1GetProjectApiKeysParams{})
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read api keys, got error: %s", err)
+		return "", diag.NewErrorDiagnostic("Client Error", msg)
+	}
+	if httpResp.JSON200 == nil {
+		msg := fmt.Sprintf("Unable to read api keys, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
+		return "", diag.NewErrorDiagnostic("Client Error", msg)
+	}
+
+	keyName = strings.ToLower(keyName)
+	for _, val := range *httpResp.JSON200 {
+		if !val.Type.IsSpecified() || val.Type.IsNull() {
+			continue
+		}
+		if !val.Id.IsSpecified() || val.Id.IsNull() {
+			continue
+		}
+
+		respType := val.Type.MustGet()
+		if respType != apiKeyType {
+			continue
+		}
+
+		// key names in the response are always lowercase, enforced API side
+		if val.Name != keyName {
+			continue
+		}
+
+		return val.Id.MustGet(), nil
+	}
+
+	return "", diag.NewErrorDiagnostic("Import Error", "Specified API key wasn't found in the project.")
 }
 
 func (r *APIKeyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/apikey_resource_test.go
+++ b/internal/provider/apikey_resource_test.go
@@ -109,3 +109,117 @@ func TestAccApiKeyResource(t *testing.T) {
 		},
 	})
 }
+
+func TestResolveAPIKeyImportID(t *testing.T) {
+	knownID := uuid.New()
+	otherID := uuid.New()
+
+	tests := []struct {
+		name string
+		id   string
+		mock func()
+
+		expectProjectRef   string
+		expectKeyID        string
+		expectErrorSummary string
+	}{
+		{
+			name:             "import by ID",
+			id:               testProjectRef + "/" + knownID.String(),
+			expectProjectRef: testProjectRef,
+			expectKeyID:      knownID.String(),
+		},
+		{
+			name: "import by name",
+			id:   testProjectRef + "/mykey",
+			mock: func() {
+				gock.New(defaultApiEndpoint).Get(apiKeysApiPath).Reply(http.StatusOK).
+					JSON([]api.ApiKeyResponse{{Id: nullable.NewNullableWithValue(knownID.String()), Name: "mykey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypeSecret)}})
+			},
+			expectProjectRef: testProjectRef,
+			expectKeyID:      knownID.String(),
+		},
+		{
+			name: "import by name and type",
+			id:   testProjectRef + "/mykey/secret",
+			mock: func() {
+				gock.New(defaultApiEndpoint).Get(apiKeysApiPath).Reply(http.StatusOK).
+					JSON([]api.ApiKeyResponse{
+						{Id: nullable.NewNullableWithValue(otherID.String()), Name: "mykey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypePublishable)},
+						{Id: nullable.NewNullableWithValue(knownID.String()), Name: "mykey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypeSecret)},
+					})
+			},
+			expectProjectRef: testProjectRef,
+			expectKeyID:      knownID.String(),
+		},
+		{
+			name: "import by name (ambiguous)",
+			id:   testProjectRef + "/mykey",
+			mock: func() {
+				gock.New(defaultApiEndpoint).Get(apiKeysApiPath).Reply(http.StatusOK).
+					JSON([]api.ApiKeyResponse{
+						{Id: nullable.NewNullableWithValue(knownID.String()), Name: "mykey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypePublishable)},
+						{Id: nullable.NewNullableWithValue(otherID.String()), Name: "mykey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypeSecret)},
+					})
+			},
+			expectErrorSummary: "Ambiguous Import Identifier",
+		},
+		{
+			name: "key name not found",
+			id:   testProjectRef + "/mykey",
+			mock: func() {
+				gock.New(defaultApiEndpoint).Get(apiKeysApiPath).Reply(http.StatusOK).
+					JSON([]api.ApiKeyResponse{
+						{Id: nullable.NewNullableWithValue(knownID.String()), Name: "knownkey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypePublishable)},
+						{Id: nullable.NewNullableWithValue(otherID.String()), Name: "otherkey", Type: nullable.NewNullableWithValue(api.ApiKeyResponseTypeSecret)},
+					})
+			},
+			expectErrorSummary: "Import Error",
+		},
+		{
+			name:               "import by name and bad type",
+			id:                 testProjectRef + "/mykey/badtype",
+			expectErrorSummary: "Unexpected Import Identifier",
+		},
+		{
+			name:               "invalid import format",
+			id:                 testProjectRef,
+			expectErrorSummary: "Unexpected Import Identifier",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gock.InterceptClient(http.DefaultClient)
+			defer gock.RestoreClient(http.DefaultClient)
+			defer gock.OffAll()
+			if tt.mock != nil {
+				tt.mock()
+			}
+
+			client, err := api.NewClientWithResponses(defaultApiEndpoint)
+			if err != nil {
+				t.Fatalf("Failed to create client: %v", err)
+			}
+
+			actualProjectRef, actualKeyID, diag := resolveAPIKeyImportID(t.Context(), client, tt.id)
+			if tt.expectErrorSummary != "" {
+				if diag == nil || diag.Summary() != tt.expectErrorSummary {
+					t.Errorf("Expected error %q, got: %v", tt.expectErrorSummary, diag)
+				}
+				return
+			}
+
+			if diag != nil {
+				t.Fatalf("Expected no error, got: %v", diag)
+			}
+
+			if tt.expectProjectRef != actualProjectRef {
+				t.Errorf("Expected ref %q, got %q", tt.expectProjectRef, actualProjectRef)
+			}
+			if tt.expectKeyID != actualKeyID {
+				t.Errorf("Expected id %q, got %q", tt.expectKeyID, actualKeyID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

API keys can only be imported by their UUID, which is not displayed in the dashboard.

## What is the new behavior?

Adds support for multiple import identifier styles:
- import by UUID
- import by name
- import by name and type

Import by name and type is needed because key names are only unique _per project within a given key type_. When multiple keys share the same name, this import style can be used to disambiguate which key should be imported.

## Additional context

Closes #276
