### PR TITLE
fix: add external X secret to copySensitiveFields

### DIFF
--- a/internal/provider/settings_resource.go
+++ b/internal/provider/settings_resource.go
@@ -574,6 +574,7 @@ func copySensitiveFields(source api.UpdateAuthConfigBody, target *api.UpdateAuth
 	target.ExternalTwitterSecret = source.ExternalTwitterSecret
 	target.ExternalWorkosSecret = source.ExternalWorkosSecret
 	target.ExternalZoomSecret = source.ExternalZoomSecret
+	target.ExternalXSecret = source.ExternalXSecret
 	// Hook provider secrets
 	target.HookCustomAccessTokenSecrets = source.HookCustomAccessTokenSecrets
 	target.HookMfaVerificationAttemptSecrets = source.HookMfaVerificationAttemptSecrets


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

`copySensitiveFields` is using `external_x_secret` value form the state instead of API returned hash

## Additional context

Fixes #310 
