### PR TITLE
fix: enforce apikey naming convention

### DIFF
--- a/internal/provider/apikey_resource.go
+++ b/internal/provider/apikey_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -18,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/oapi-codegen/nullable"
@@ -93,6 +96,12 @@ func (d *APIKeyResource) Schema(ctx context.Context, req resource.SchemaRequest,
 			"name": schema.StringAttribute{
 				MarkdownDescription: "Name of the API key",
 				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-z_][a-z0-9_]*$`),
+						"Name must start with a lowercase letter or an underscore, followed only by lowercase alphanumeric characters or underscore",
+					),
+				},
 			},
 			"description": schema.StringAttribute{
 				MarkdownDescription: "Description of the API key",

--- a/internal/provider/apikey_resource_test.go
+++ b/internal/provider/apikey_resource_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 
 	"github.com/google/uuid"
@@ -20,6 +21,13 @@ const testAccApikeyResourceConfig = `
 resource "supabase_apikey" "new" {
   project_ref = "` + testProjectRef + `"
   name        = "test"
+}
+`
+
+const testAccApikeyResourceConfigInvalidName = `
+resource "supabase_apikey" "new" {
+  project_ref = "` + testProjectRef + `"
+  name        = "Invalid-Name-123" # Contains capital letters and hyphens
 }
 `
 
@@ -106,6 +114,19 @@ func TestAccApiKeyResource(t *testing.T) {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccApiKeyResource_InvalidName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccApikeyResourceConfigInvalidName,
+				ExpectError: regexp.MustCompile(`Name must start with a lowercase letter or an underscore`),
+			},
 		},
 	})
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hello! This is a "bug" fix / QOL update to enforce the api_key naming requirements at the provider level.

## What is the current behavior?

Currently the provider will allow you to supply any name for api keys and only fail on apply when trying to create the resource.
Giving the below error:
```
Error: Client Error

  with module.supabase_database.supabase_apikey.api_key,
  on .terraform/modules/supabase_database/main.tf line 26, in resource "supabase_apikey" "api_key":
  26: resource "supabase_apikey" "api_key" {

Unable to create apiKey, got status 400: {"message":"name: Name must start
with a lowercase letter or an underscore, followed only by lowercase
alphanumeric characters or underscore"}
```

## What is the new behavior?

This new behaviour will make it so if an incorrect naming format is given it will be caught well before the apply. 

## Additional context

Add any other context or screenshots.

- Adds a simple test to check if an invalid name causes a failure (is there a better way to do this? 😄)

thank you!