### PR TITLE
chore(docs): add a callout for auth fields that dont support out-of-band diff

### DIFF
--- a/docs/resources/settings.md
+++ b/docs/resources/settings.md
@@ -65,7 +65,11 @@ resource "supabase_settings" "production" {
 ### Optional
 
 - `api` (String) API settings as [serialised JSON](https://api.supabase.com/api/v1#/services/updatePostgRESTConfig)
-- `auth` (String) Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig)
+- `auth` (String) Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig).
+
+~> Several fields are returned as a hash by the API rather than plaintext. The provider preserves these fields from prior state, so out-of-band changes will not appear in `terraform plan`.
+
+Affected fields: `smtp_pass`, `sms_twilio_auth_token`, `sms_twilio_verify_auth_token`, `sms_messagebird_access_key`, `sms_textlocal_api_key`, `sms_vonage_api_secret`, `security_captcha_secret`, `external_apple_secret`, `external_azure_secret`, `external_bitbucket_secret`, `external_discord_secret`, `external_facebook_secret`, `external_figma_secret`, `external_github_secret`, `external_gitlab_secret`, `external_google_secret`, `external_kakao_secret`, `external_keycloak_secret`, `external_linkedin_oidc_secret`, `external_notion_secret`, `external_slack_oidc_secret`, `external_slack_secret`, `external_spotify_secret`, `external_twitch_secret`, `external_twitter_secret`, `external_workos_secret`, `external_x_secret`, `external_zoom_secret`, `hook_custom_access_token_secrets`, `hook_mfa_verification_attempt_secrets`, `hook_password_verification_attempt_secrets`, `hook_send_email_secrets`, `hook_send_sms_secrets`.
 - `database` (String) Database settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateConfig)
 - `network` (String) Network settings as serialised JSON
 - `pooler` (String) Pooler settings as serialised JSON

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -413,7 +413,7 @@
               },
               "auth": {
                 "type": "string",
-                "description": "Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig)",
+                "description": "Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig).\n\n~> Several fields are returned as a hash by the API rather than plaintext. The provider preserves these fields from prior state, so out-of-band changes will not appear in `terraform plan`.\n\nAffected fields: `smtp_pass`, `sms_twilio_auth_token`, `sms_twilio_verify_auth_token`, `sms_messagebird_access_key`, `sms_textlocal_api_key`, `sms_vonage_api_secret`, `security_captcha_secret`, `external_apple_secret`, `external_azure_secret`, `external_bitbucket_secret`, `external_discord_secret`, `external_facebook_secret`, `external_figma_secret`, `external_github_secret`, `external_gitlab_secret`, `external_google_secret`, `external_kakao_secret`, `external_keycloak_secret`, `external_linkedin_oidc_secret`, `external_notion_secret`, `external_slack_oidc_secret`, `external_slack_secret`, `external_spotify_secret`, `external_twitch_secret`, `external_twitter_secret`, `external_workos_secret`, `external_x_secret`, `external_zoom_secret`, `hook_custom_access_token_secrets`, `hook_mfa_verification_attempt_secrets`, `hook_password_verification_attempt_secrets`, `hook_send_email_secrets`, `hook_send_sms_secrets`.",
                 "description_kind": "markdown",
                 "optional": true
               },

--- a/internal/provider/settings_resource.go
+++ b/internal/provider/settings_resource.go
@@ -95,9 +95,16 @@ func (r *SettingsResource) Schema(ctx context.Context, req resource.SchemaReques
 				Optional:            true,
 			},
 			"auth": schema.StringAttribute{
-				CustomType:          jsontypes.NormalizedType{},
-				MarkdownDescription: "Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig)",
-				Optional:            true,
+				CustomType: jsontypes.NormalizedType{},
+				MarkdownDescription: "Auth settings as [serialised JSON](https://api.supabase.com/api/v1#/projects%20config/updateV1AuthConfig).\n\n" +
+					"~> Several fields are returned as a hash by the API rather than plaintext. The provider preserves these fields from prior state, so out-of-band changes will not appear in `terraform plan`.\n\n" +
+					"Affected fields: `smtp_pass`, `sms_twilio_auth_token`, `sms_twilio_verify_auth_token`, `sms_messagebird_access_key`, `sms_textlocal_api_key`, `sms_vonage_api_secret`, " +
+					"`security_captcha_secret`, `external_apple_secret`, `external_azure_secret`, `external_bitbucket_secret`, `external_discord_secret`, `external_facebook_secret`, " +
+					"`external_figma_secret`, `external_github_secret`, `external_gitlab_secret`, `external_google_secret`, `external_kakao_secret`, `external_keycloak_secret`, " +
+					"`external_linkedin_oidc_secret`, `external_notion_secret`, `external_slack_oidc_secret`, `external_slack_secret`, `external_spotify_secret`, `external_twitch_secret`, " +
+					"`external_twitter_secret`, `external_workos_secret`, `external_x_secret`, `external_zoom_secret`, `hook_custom_access_token_secrets`, `hook_mfa_verification_attempt_secrets`, " +
+					"`hook_password_verification_attempt_secrets`, `hook_send_email_secrets`, `hook_send_sms_secrets`.",
+				Optional: true,
 			},
 			"api": schema.StringAttribute{
 				CustomType:          jsontypes.NormalizedType{},


### PR DESCRIPTION
## What kind of change does this PR introduce?

Doc update

## What is the current behavior?

Some fields in the `auth` settings will not be detected as changed by the provider after an out of band update. Those are currently not documented.

## What is the new behavior?

The fields that exhibit this behavior are explicitly listed in the docs.

<img width="896" height="665" alt="Screenshot 2026-05-20 at 13 34 28" src="https://github.com/user-attachments/assets/e209a719-09bf-41f6-8fdf-74d906be42ba" />

## Additional context

Closes #211
