### PR TITLE
chore: add make generate target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -49,3 +49,12 @@ generate-json:
 
 	@echo "Cleaning up"
 	@rm -r temp
+
+# Generate terraform docs
+.PHONY: generate-docs
+generate-docs:
+	@go generate ./...
+
+# Runs all generate targets
+.PHONY: generate
+generate: generate-docs generate-json


### PR DESCRIPTION
## What is the new behavior?

`make generate` runs both schema.json and doc gen 

