### PR TITLE
feat: support declaration of persistent branches

### DIFF
--- a/docs/resources/branch.md
+++ b/docs/resources/branch.md
@@ -29,6 +29,7 @@ resource "supabase_branch" "new" {
 
 ### Optional
 
+- `persistent` (Boolean) Branch persistency, default false (preview branch)
 - `region` (String) Database region
 
 ### Read-Only

--- a/docs/resources/branch.md
+++ b/docs/resources/branch.md
@@ -61,5 +61,8 @@ The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/c
 # Branches can be imported using the branch ID.
 #
 # - branch_id: The UUID of the branch. Run `supabase branches list` to find it.
+#
+# For a persistent branch, set `persistent = true` in the resource configuration before the first plan or apply after import.
+# Import cannot currently determine the branch's existing persistence setting.
 terraform import supabase_branch.development <branch_id>
 ```

--- a/docs/resources/branch.md
+++ b/docs/resources/branch.md
@@ -29,7 +29,7 @@ resource "supabase_branch" "new" {
 
 ### Optional
 
-- `persistent` (Boolean) Branch persistency, default false (preview branch)
+- `persistent` (Boolean) Branch persistency
 - `region` (String) Database region
 
 ### Read-Only

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -168,6 +168,13 @@
                 "description_kind": "markdown",
                 "required": true
               },
+              "persistent": {
+                "type": "bool",
+                "description": "Branch persistency",
+                "description_kind": "markdown",
+                "optional": true,
+                "computed": true
+              },
               "region": {
                 "type": "string",
                 "description": "Database region",

--- a/examples/resources/supabase_branch/import.sh
+++ b/examples/resources/supabase_branch/import.sh
@@ -1,4 +1,7 @@
 # Branches can be imported using the branch ID.
 #
 # - branch_id: The UUID of the branch. Run `supabase branches list` to find it.
+#
+# For a persistent branch, set `persistent = true` in the resource configuration before the first plan or apply after import.
+# Import cannot currently determine the branch's existing persistence setting.
 terraform import supabase_branch.development <branch_id>

--- a/internal/provider/branch_resource.go
+++ b/internal/provider/branch_resource.go
@@ -270,10 +270,10 @@ func readBranch(ctx context.Context, state *BranchResourceModel, client *api.Cli
 }
 
 func readBranchPersistent(ctx context.Context, state *BranchResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
-	if state.ParentProjectRef.IsNull() || state.GitBranch.IsNull() {
+	if state.ParentProjectRef.IsNull() || state.Id.IsNull() {
 		return nil
 	}
-	httpResp, err := client.V1GetABranchWithResponse(ctx, state.ParentProjectRef.ValueString(), state.GitBranch.ValueString())
+	httpResp, err := client.V1ListAllBranchesWithResponse(ctx, state.ParentProjectRef.ValueString())
 	if err != nil {
 		msg := fmt.Sprintf("Unable to read branch, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
@@ -282,7 +282,12 @@ func readBranchPersistent(ctx context.Context, state *BranchResourceModel, clien
 		msg := fmt.Sprintf("Unable to read branch, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-	state.Persistent = types.BoolValue(httpResp.JSON200.Persistent)
+	for _, branch := range *httpResp.JSON200 {
+		if branch.Id.String() == state.Id.ValueString() {
+			state.Persistent = types.BoolValue(branch.Persistent)
+			return nil
+		}
+	}
 	return nil
 }
 

--- a/internal/provider/branch_resource.go
+++ b/internal/provider/branch_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -65,6 +66,7 @@ type BranchResourceModel struct {
 	GitBranch        types.String `tfsdk:"git_branch"`
 	ParentProjectRef types.String `tfsdk:"parent_project_ref"`
 	Region           types.String `tfsdk:"region"`
+	Persistent       types.Bool   `tfsdk:"persistent"`
 	Database         types.Object `tfsdk:"database"`
 	Id               types.String `tfsdk:"id"`
 }
@@ -93,6 +95,12 @@ func (r *BranchResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"persistent": schema.BoolAttribute{
+				MarkdownDescription: "Branch persistency",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
 			},
 			"database": schema.SingleNestedAttribute{
 				MarkdownDescription: "Database connection details",
@@ -232,6 +240,7 @@ func updateBranch(ctx context.Context, plan *BranchResourceModel, client *api.Cl
 	httpResp, err := client.V1UpdateABranchConfigWithResponse(ctx, plan.Id.ValueString(), api.UpdateBranchBody{
 		BranchName: plan.GitBranch.ValueStringPointer(),
 		GitBranch:  plan.GitBranch.ValueStringPointer(),
+		Persistent: plan.Persistent.ValueBoolPointer(),
 	})
 	if err != nil {
 		msg := fmt.Sprintf("Unable to update branch, got error: %s", err)
@@ -244,6 +253,7 @@ func updateBranch(ctx context.Context, plan *BranchResourceModel, client *api.Cl
 
 	plan.ParentProjectRef = types.StringValue(httpResp.JSON200.ParentProjectRef)
 	plan.GitBranch = types.StringPointerValue(httpResp.JSON200.GitBranch)
+	plan.Persistent = types.BoolValue(httpResp.JSON200.Persistent)
 	if diag := readBranchDatabase(ctx, plan, client); diag.HasError() {
 		for _, err := range diag.Errors() {
 			tflog.Warn(ctx, fmt.Sprintf("%s: %s", err.Summary(), err.Detail()))
@@ -253,7 +263,27 @@ func updateBranch(ctx context.Context, plan *BranchResourceModel, client *api.Cl
 }
 
 func readBranch(ctx context.Context, state *BranchResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
-	return readBranchDatabase(ctx, state, client)
+	if diags := readBranchDatabase(ctx, state, client); diags.HasError() {
+		return diags
+	}
+	return readBranchPersistent(ctx, state, client)
+}
+
+func readBranchPersistent(ctx context.Context, state *BranchResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
+	if state.ParentProjectRef.IsNull() || state.GitBranch.IsNull() {
+		return nil
+	}
+	httpResp, err := client.V1GetABranchWithResponse(ctx, state.ParentProjectRef.ValueString(), state.GitBranch.ValueString())
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read branch, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	if httpResp.JSON200 == nil {
+		msg := fmt.Sprintf("Unable to read branch, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	state.Persistent = types.BoolValue(httpResp.JSON200.Persistent)
+	return nil
 }
 
 func readBranchDatabase(ctx context.Context, state *BranchResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
@@ -313,6 +343,7 @@ func createBranch(ctx context.Context, plan *BranchResourceModel, client *api.Cl
 		BranchName: plan.GitBranch.ValueString(),
 		GitBranch:  plan.GitBranch.ValueStringPointer(),
 		Region:     plan.Region.ValueStringPointer(),
+		Persistent: plan.Persistent.ValueBoolPointer(),
 	})
 	if err != nil {
 		msg := fmt.Sprintf("Unable to create branch, got error: %s", err)
@@ -324,6 +355,7 @@ func createBranch(ctx context.Context, plan *BranchResourceModel, client *api.Cl
 	}
 	// Update computed fields
 	plan.Id = types.StringValue(httpResp.JSON201.Id.String())
+	plan.Persistent = types.BoolValue(httpResp.JSON201.Persistent)
 	if diag := readBranchDatabase(ctx, plan, client); diag.HasError() {
 		for _, err := range diag.Errors() {
 			tflog.Warn(ctx, fmt.Sprintf("%s: %s", err.Summary(), err.Detail()))
@@ -338,8 +370,34 @@ func deleteBranch(ctx context.Context, state *BranchResourceModel, client *api.C
 		msg := fmt.Sprintf("Unable to delete branch, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
+	// on 422 --> attempt demote and retry
+	if httpResp.StatusCode() == http.StatusUnprocessableEntity {
+		if diags := demoteBranch(ctx, state, client); diags.HasError() {
+			return diags
+		}
+		httpResp, err = client.V1DeleteABranchWithResponse(ctx, state.Id.ValueString(), &api.V1DeleteABranchParams{})
+		if err != nil {
+			msg := fmt.Sprintf("Unable to delete branch, got error: %s", err)
+			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+		}
+	}
 	if httpResp.StatusCode() != http.StatusOK {
 		msg := fmt.Sprintf("Unable to delete branch, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	return nil
+}
+
+func demoteBranch(ctx context.Context, state *BranchResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
+	httpResp, err := client.V1UpdateABranchConfigWithResponse(ctx, state.Id.ValueString(), api.UpdateBranchBody{
+		Persistent: Ptr(false),
+	})
+	if err != nil {
+		msg := fmt.Sprintf("Unable to demote persistent branch, got error: %s", err)
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
+	}
+	if httpResp.JSON200 == nil {
+		msg := fmt.Sprintf("Unable to demote persistent branch, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 	return nil

--- a/internal/provider/branch_resource_test.go
+++ b/internal/provider/branch_resource_test.go
@@ -19,6 +19,7 @@ const (
 resource "supabase_branch" "new" {
   parent_project_ref = "` + testProjectRef + `"
   git_branch         = "develop"
+  persistent         = true
 }
 `
 )
@@ -91,6 +92,7 @@ func TestAccBranchResource(t *testing.T) {
 			Id:               uuid.MustParse(testBranchUUID),
 			ParentProjectRef: testProjectRef,
 			GitBranch:        Ptr("develop"),
+			Persistent:       true,
 		})
 	gock.New(defaultApiEndpoint).
 		Get(branchApiPath).
@@ -102,8 +104,16 @@ func TestAccBranchResource(t *testing.T) {
 		JSON(api.BranchResponse{
 			ParentProjectRef: testProjectRef,
 			GitBranch:        Ptr("develop"),
+			Persistent:       true,
 		})
-	// Step 4: delete
+	// Step 4: delete (persistent branch — rejected, demoted, then deleted)
+	gock.New(defaultApiEndpoint).
+		Delete(branchApiPath).
+		Reply(http.StatusUnprocessableEntity)
+	gock.New(defaultApiEndpoint).
+		Patch(branchApiPath).
+		Reply(http.StatusOK).
+		JSON(api.BranchResponse{})
 	gock.New(defaultApiEndpoint).
 		Delete(branchApiPath).
 		Reply(http.StatusOK)
@@ -132,6 +142,7 @@ func TestAccBranchResource(t *testing.T) {
 				Config: testAccBranchResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("supabase_branch.new", "git_branch", "develop"),
+					resource.TestCheckResourceAttr("supabase_branch.new", "persistent", "true"),
 					// resource.TestCheckResourceAttrSet("supabase_branch.new", "database"),
 				),
 			},

--- a/internal/provider/branch_resource_test.go
+++ b/internal/provider/branch_resource_test.go
@@ -56,6 +56,13 @@ func TestAccBranchResource(t *testing.T) {
 		Get(branchApiPath).
 		Reply(http.StatusOK).
 		JSON(api.BranchDetailResponse{})
+	gock.New(defaultApiEndpoint).
+		Get(branchesApiPath + "/main").
+		Reply(http.StatusOK).
+		JSON(api.BranchResponse{
+			ParentProjectRef: testProjectRef,
+			GitBranch:        Ptr("main"),
+		})
 	// Step 2: read
 	gock.New(defaultApiEndpoint).
 		Get(branchApiPath).
@@ -71,6 +78,13 @@ func TestAccBranchResource(t *testing.T) {
 		Reply(http.StatusOK).
 		JSON(api.BranchDetailResponse{})
 	gock.New(defaultApiEndpoint).
+		Get(branchesApiPath + "/main").
+		Reply(http.StatusOK).
+		JSON(api.BranchResponse{
+			ParentProjectRef: testProjectRef,
+			GitBranch:        Ptr("main"),
+		})
+	gock.New(defaultApiEndpoint).
 		Patch(branchApiPath).
 		Reply(http.StatusOK).
 		JSON(api.BranchResponse{
@@ -82,6 +96,13 @@ func TestAccBranchResource(t *testing.T) {
 		Get(branchApiPath).
 		Reply(http.StatusOK).
 		JSON(api.BranchDetailResponse{})
+	gock.New(defaultApiEndpoint).
+		Get(branchesApiPath + "/develop").
+		Reply(http.StatusOK).
+		JSON(api.BranchResponse{
+			ParentProjectRef: testProjectRef,
+			GitBranch:        Ptr("develop"),
+		})
 	// Step 4: delete
 	gock.New(defaultApiEndpoint).
 		Delete(branchApiPath).
@@ -96,6 +117,7 @@ func TestAccBranchResource(t *testing.T) {
 				Config: examples.BranchResourceConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("supabase_branch.new", "id", testBranchUUID),
+					resource.TestCheckResourceAttr("supabase_branch.new", "persistent", "false"),
 				),
 			},
 			// ImportState testing
@@ -103,7 +125,7 @@ func TestAccBranchResource(t *testing.T) {
 				ResourceName:            "supabase_branch.new",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"git_branch", "parent_project_ref"},
+				ImportStateVerifyIgnore: []string{"git_branch", "parent_project_ref", "persistent"},
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/branch_resource_test.go
+++ b/internal/provider/branch_resource_test.go
@@ -58,12 +58,13 @@ func TestAccBranchResource(t *testing.T) {
 		Reply(http.StatusOK).
 		JSON(api.BranchDetailResponse{})
 	gock.New(defaultApiEndpoint).
-		Get(branchesApiPath + "/main").
+		Get(branchesApiPath).
 		Reply(http.StatusOK).
-		JSON(api.BranchResponse{
+		JSON([]api.BranchResponse{{
+			Id:               uuid.MustParse(testBranchUUID),
 			ParentProjectRef: testProjectRef,
 			GitBranch:        Ptr("main"),
-		})
+		}})
 	// Step 2: read
 	gock.New(defaultApiEndpoint).
 		Get(branchApiPath).
@@ -79,12 +80,13 @@ func TestAccBranchResource(t *testing.T) {
 		Reply(http.StatusOK).
 		JSON(api.BranchDetailResponse{})
 	gock.New(defaultApiEndpoint).
-		Get(branchesApiPath + "/main").
+		Get(branchesApiPath).
 		Reply(http.StatusOK).
-		JSON(api.BranchResponse{
+		JSON([]api.BranchResponse{{
+			Id:               uuid.MustParse(testBranchUUID),
 			ParentProjectRef: testProjectRef,
 			GitBranch:        Ptr("main"),
-		})
+		}})
 	gock.New(defaultApiEndpoint).
 		Patch(branchApiPath).
 		Reply(http.StatusOK).
@@ -99,13 +101,14 @@ func TestAccBranchResource(t *testing.T) {
 		Reply(http.StatusOK).
 		JSON(api.BranchDetailResponse{})
 	gock.New(defaultApiEndpoint).
-		Get(branchesApiPath + "/develop").
+		Get(branchesApiPath).
 		Reply(http.StatusOK).
-		JSON(api.BranchResponse{
+		JSON([]api.BranchResponse{{
+			Id:               uuid.MustParse(testBranchUUID),
 			ParentProjectRef: testProjectRef,
 			GitBranch:        Ptr("develop"),
 			Persistent:       true,
-		})
+		}})
 	// Step 4: delete (persistent branch — rejected, demoted, then deleted)
 	gock.New(defaultApiEndpoint).
 		Delete(branchApiPath).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The supabase_branch resource can only manage preview branches. The API already supports persistent branches via the persistent flag on CreateBranchBody / UpdateBranchBody, but the provider doesn't expose it.

Persistent branches also can't be deleted directly since the delete API returns 422 until they're demoted, so they can't be appropriately destroyed.

## What is the new behavior?

Adds an optional persistent boolean to supabase_branch (default false --> preview branch):

- persistent is Optional + Computed, defaulting to false
- Create / Update — send Persistent on CreateBranchBody / UpdateBranchBody, already supported by the API
- Read — refreshes persistent from the API. Because the existing Read path uses V1GetABranchConfig (BranchDetailResponse), which does not carry the persistent flag, a new readBranchPersistent helper calls V1GetABranch(parent_ref, git_branch) --> BranchResponse, which does
- Delete — on 422, tries to demote the branch (PATCH persistent=false) and retry the delete

## Additional context
The Read solution is pretty hacky and involves an extra lookup operation every time; it might be worth just letting persistent go stale/treating it as write-only, since it's never necessary to know the correct value. But I've implemented the extra lookup to keep it in sync when read for the time being.
