### PR TITLE
fix: wait for branch project refs via the branches endpoint

### DIFF
--- a/internal/provider/constants_test.go
+++ b/internal/provider/constants_test.go
@@ -21,6 +21,14 @@ const (
 	sslEnforcementApiPath      = projectApiPath + "/ssl-enforcement"
 	secretsApiPath             = projectApiPath + "/secrets"
 
+	// A branch ref resolves on /v1/branches/{ref} but returns 404 on /v1/projects/{ref}.
+	testBranchRef           = "zyxwvutsrqponmlkjihg" //nolint:gosec
+	branchProjectApiPath    = projectsApiPath + "/" + testBranchRef
+	branchRefApiPath        = "/v1/branches/" + testBranchRef
+	branchHealthApiPath     = branchProjectApiPath + "/health"
+	branchPostgrestApiPath  = branchProjectApiPath + "/postgrest"
+	branchAuthConfigApiPath = branchProjectApiPath + "/config/auth"
+
 	functionSlug              = "foo"
 	testApiKeyUUID            = "d9bece6b-52cc-4d67-a948-2349d46676f5" //nolint:gosec
 	testThirdPartyAuthUUID    = "88888888-8888-4888-8888-888888888888" //nolint:gosec

--- a/internal/provider/settings_resource_test.go
+++ b/internal/provider/settings_resource_test.go
@@ -1727,3 +1727,103 @@ func TestAccSettingsResource_SslEnforcementReadIgnoresAppliedSuccessfully(t *tes
 		},
 	})
 }
+
+// Branch refs return 404 from /v1/projects/{ref}; their status is served by
+// /v1/branches/{ref} instead. Settings must still apply against them.
+// https://github.com/supabase/terraform-provider-supabase/issues/345
+func TestAccSettingsResource_BranchRef(t *testing.T) {
+	defer gock.OffAll()
+
+	exactBranchProjectPath := func(req *http.Request, _ *gock.Request) (bool, error) {
+		return req.URL.Path == branchProjectApiPath, nil
+	}
+	branchAuthResponse := func(jwtExp int) api.AuthConfigResponse {
+		return api.AuthConfigResponse{
+			SiteUrl:           nullable.NewNullableWithValue("http://localhost:3000"),
+			JwtExp:            nullable.NewNullableWithValue(jwtExp),
+			MailerOtpExp:      3600,
+			MfaPhoneOtpLength: 6,
+			SmsOtpLength:      6,
+			SmtpAdminEmail:    nullable.NewNullNullable[openapi_types.Email](),
+		}
+	}
+	branchConfig := func(jwtExp int) string {
+		return fmt.Sprintf(`
+resource "supabase_settings" "branch" {
+  project_ref = "%s"
+
+  auth = jsonencode({
+    site_url = "http://localhost:3000"
+    jwt_exp  = %d
+  })
+}
+`, testBranchRef, jwtExp)
+	}
+
+	// Create and update each wait for the project to become active; branch
+	// refs 404 on the projects endpoint and resolve on the branches endpoint.
+	for range 2 {
+		gock.New(defaultApiEndpoint).
+			Get(branchProjectApiPath).
+			AddMatcher(exactBranchProjectPath).
+			Reply(http.StatusNotFound).
+			JSON(map[string]string{"message": "Project not found"})
+		gock.New(defaultApiEndpoint).
+			Get(branchRefApiPath).
+			Reply(http.StatusOK).
+			JSON(api.BranchDetailResponse{
+				Ref:    testBranchRef,
+				Status: api.BranchDetailResponseStatusACTIVEHEALTHY,
+			})
+		gock.New(defaultApiEndpoint).
+			Get(branchPostgrestApiPath).
+			Reply(http.StatusOK).
+			JSON(api.V1PostgrestConfigResponse{DbSchema: "public,storage,graphql_public"})
+		gock.New(defaultApiEndpoint).
+			Get(branchHealthApiPath).
+			Reply(http.StatusOK).
+			JSON(allServicesHealthy)
+	}
+
+	// Step 1: create
+	gock.New(defaultApiEndpoint).
+		Patch(branchAuthConfigApiPath).
+		Reply(http.StatusOK).
+		JSON(branchAuthResponse(3600))
+	for range 2 {
+		gock.New(defaultApiEndpoint).
+			Get(branchAuthConfigApiPath).
+			Reply(http.StatusOK).
+			JSON(branchAuthResponse(3600))
+	}
+	// Step 2: update
+	gock.New(defaultApiEndpoint).
+		Patch(branchAuthConfigApiPath).
+		Reply(http.StatusOK).
+		JSON(branchAuthResponse(1800))
+	for range 2 {
+		gock.New(defaultApiEndpoint).
+			Get(branchAuthConfigApiPath).
+			Reply(http.StatusOK).
+			JSON(branchAuthResponse(1800))
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: branchConfig(3600),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_settings.branch", "id", testBranchRef),
+				),
+			},
+			{
+				Config: branchConfig(1800),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_settings.branch", "id", testBranchRef),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"slices"
 	"strings"
 	"time"
@@ -64,6 +65,11 @@ func waitForProjectActive(ctx context.Context, projectRef string, client *api.Cl
 			if err != nil {
 				return nil, "", fmt.Errorf("failed to get project status: %w", err)
 			}
+			// Branch refs are not served by the projects endpoint and return 404.
+			// Their status is available from the branches endpoint instead.
+			if httpResp.StatusCode() == http.StatusNotFound {
+				return refreshBranchStatus(ctx, projectRef, client, httpResp)
+			}
 			if httpResp.JSON200 == nil {
 				return nil, "", fmt.Errorf("unexpected status %d: %s", httpResp.StatusCode(), httpResp.Body)
 			}
@@ -91,6 +97,35 @@ func waitForProjectActive(ctx context.Context, projectRef string, client *api.Cl
 		)}
 	}
 	return nil
+}
+
+// refreshBranchStatus polls branch status for refs that 404 on the projects
+// endpoint. BranchDetailResponseStatus shares its values with the project
+// status enum, so the result feeds the same state machine.
+func refreshBranchStatus(ctx context.Context, projectRef string, client *api.ClientWithResponses, projectResp *api.V1GetProjectResponse) (any, string, error) {
+	httpResp, err := client.V1GetABranchConfigWithResponse(ctx, projectRef)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get branch status: %w", err)
+	}
+	if httpResp.StatusCode() == http.StatusNotFound {
+		// Not a branch ref either; surface the original project lookup failure.
+		return nil, "", fmt.Errorf("unexpected status %d: %s", projectResp.StatusCode(), projectResp.Body)
+	}
+	if httpResp.JSON200 == nil {
+		return nil, "", fmt.Errorf("unexpected status %d: %s", httpResp.StatusCode(), httpResp.Body)
+	}
+
+	status := string(httpResp.JSON200.Status)
+	tflog.Debug(ctx, "Waiting for branch to become active", map[string]interface{}{
+		"branch_ref": projectRef,
+		"status":     status,
+	})
+
+	if slices.Contains(terminalProjectStatuses, api.V1ProjectWithDatabaseResponseStatus(status)) {
+		return nil, "", fmt.Errorf("branch %s in terminal state: %s", projectRef, status)
+	}
+
+	return httpResp.JSON200, status, nil
 }
 
 const (

--- a/internal/provider/utils_test.go
+++ b/internal/provider/utils_test.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"net/http"
 	"slices"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -39,6 +40,159 @@ func TestWaitForProjectActive_TerminalState(t *testing.T) {
 
 	if !diags.HasError() {
 		t.Errorf("Expected error for terminal state, got success")
+	}
+}
+
+func TestWaitForProjectActive_BranchRefFallsBackToBranchesEndpoint(t *testing.T) {
+	defer gock.OffAll()
+	gock.InterceptClient(http.DefaultClient)
+	defer gock.RestoreClient(http.DefaultClient)
+
+	// Branch refs are not returned by the projects endpoint.
+	gock.New(defaultApiEndpoint).
+		Get(branchProjectApiPath).
+		Reply(http.StatusNotFound).
+		JSON(map[string]string{"message": "Project not found"})
+
+	gock.New(defaultApiEndpoint).
+		Get(branchRefApiPath).
+		Reply(http.StatusOK).
+		JSON(api.BranchDetailResponse{
+			Ref:    testBranchRef,
+			Status: api.BranchDetailResponseStatusACTIVEHEALTHY,
+		})
+
+	client, err := api.NewClientWithResponses(defaultApiEndpoint)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	diags := waitForProjectActive(t.Context(), testBranchRef, client, 5*time.Minute)
+	if diags.HasError() {
+		t.Errorf("Expected success for active branch ref, got errors: %v", diags)
+	}
+}
+
+func TestWaitForProjectActive_BranchRefPollsUntilActive(t *testing.T) {
+	defer gock.OffAll()
+	gock.InterceptClient(http.DefaultClient)
+	defer gock.RestoreClient(http.DefaultClient)
+
+	for _, status := range []api.BranchDetailResponseStatus{
+		api.BranchDetailResponseStatusCOMINGUP,
+		api.BranchDetailResponseStatusACTIVEHEALTHY,
+	} {
+		gock.New(defaultApiEndpoint).
+			Get(branchProjectApiPath).
+			Reply(http.StatusNotFound).
+			JSON(map[string]string{"message": "Project not found"})
+		gock.New(defaultApiEndpoint).
+			Get(branchRefApiPath).
+			Reply(http.StatusOK).
+			JSON(api.BranchDetailResponse{
+				Ref:    testBranchRef,
+				Status: status,
+			})
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		client, err := api.NewClientWithResponses(defaultApiEndpoint)
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+
+		diags := waitForProjectActive(t.Context(), testBranchRef, client, 5*time.Minute)
+		if diags.HasError() {
+			t.Errorf("Expected success once branch becomes active, got errors: %v", diags)
+		}
+	})
+}
+
+func TestWaitForProjectActive_BranchRefTerminalState(t *testing.T) {
+	defer gock.OffAll()
+	gock.InterceptClient(http.DefaultClient)
+	defer gock.RestoreClient(http.DefaultClient)
+
+	gock.New(defaultApiEndpoint).
+		Get(branchProjectApiPath).
+		Reply(http.StatusNotFound).
+		JSON(map[string]string{"message": "Project not found"})
+
+	gock.New(defaultApiEndpoint).
+		Get(branchRefApiPath).
+		Reply(http.StatusOK).
+		JSON(api.BranchDetailResponse{
+			Ref:    testBranchRef,
+			Status: api.BranchDetailResponseStatusINITFAILED,
+		})
+
+	client, err := api.NewClientWithResponses(defaultApiEndpoint)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	diags := waitForProjectActive(t.Context(), testBranchRef, client, 5*time.Minute)
+	if !diags.HasError() {
+		t.Errorf("Expected error for branch in terminal state, got success")
+	}
+}
+
+func TestWaitForProjectActive_UnknownRefFails(t *testing.T) {
+	defer gock.OffAll()
+	gock.InterceptClient(http.DefaultClient)
+	defer gock.RestoreClient(http.DefaultClient)
+
+	gock.New(defaultApiEndpoint).
+		Get(branchProjectApiPath).
+		Reply(http.StatusNotFound).
+		JSON(map[string]string{"message": "Project not found"})
+
+	gock.New(defaultApiEndpoint).
+		Get(branchRefApiPath).
+		Reply(http.StatusNotFound).
+		JSON(map[string]string{"message": "Branch not found"})
+
+	client, err := api.NewClientWithResponses(defaultApiEndpoint)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	diags := waitForProjectActive(t.Context(), testBranchRef, client, 5*time.Minute)
+	if !diags.HasError() {
+		t.Errorf("Expected error for ref unknown to both endpoints, got success")
+	}
+	// The original project lookup failure is surfaced, not the branch 404.
+	if detail := diags.Errors()[0].Detail(); !strings.Contains(detail, "Project not found") {
+		t.Errorf("Expected error to surface the project lookup failure, got: %s", detail)
+	}
+}
+
+func TestWaitForProjectActive_BranchEndpointErrorFails(t *testing.T) {
+	defer gock.OffAll()
+	gock.InterceptClient(http.DefaultClient)
+	defer gock.RestoreClient(http.DefaultClient)
+
+	gock.New(defaultApiEndpoint).
+		Get(branchProjectApiPath).
+		Reply(http.StatusNotFound).
+		JSON(map[string]string{"message": "Project not found"})
+
+	gock.New(defaultApiEndpoint).
+		Get(branchRefApiPath).
+		Reply(http.StatusInternalServerError).
+		JSON(map[string]string{"message": "Internal server error"})
+
+	client, err := api.NewClientWithResponses(defaultApiEndpoint)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	diags := waitForProjectActive(t.Context(), testBranchRef, client, 5*time.Minute)
+	if !diags.HasError() {
+		t.Errorf("Expected error when branches endpoint fails, got success")
+	}
+	if detail := diags.Errors()[0].Detail(); !strings.Contains(detail, "unexpected status 500") {
+		t.Errorf("Expected error to surface the branches endpoint failure, got: %s", detail)
 	}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix — fixes #345.

Since v1.7.0, `supabase_settings` fails on Create/Update when `project_ref` is a **branch** ref (e.g. `supabase_branch.x.database.id`):

```
Error: Project Not Ready
Project <branch-ref> did not become active within timeout: unexpected status 404: {"message":"Project not found"}
```

#272 added a `waitForProjectActive` gate that polls `GET /v1/projects/{ref}` and treats any non-200 as fatal (a `Refresh` error aborts `retry.StateChangeConf` immediately — the "timeout" wording is misleading; it fails on the first poll). Branch refs are not served by that endpoint, so the gate broke the settings-on-branch pattern that worked through v1.6.2 and that Supabase's own example uses ([supabase-action-example `preview.tf`](https://github.com/supabase/supabase-action-example/blob/f21060975e7a8d76a75a3f547f2873fa4f8ee945/supabase/remotes/preview.tf#L31)).

Verified against the live Management API with a branch ref (matching the reporter's findings in #345):

| Endpoint | Status |
| --- | --- |
| `GET /v1/projects/{branch-ref}` | 404 |
| `GET /v1/branches/{branch-ref}` | 200, `status: ACTIVE_HEALTHY` |
| `GET /v1/projects/{branch-ref}/health` | 200, all services |
| `GET /v1/projects/{branch-ref}/postgrest` | 200 |

So only `waitForProjectActive` needs changing — the config and health endpoints all accept branch refs, meaning `waitForServicesActive` / `waitForAuthServiceActive` already work.

## What is the current behavior?

`waitForProjectActive` aborts on the projects endpoint's 404, so `supabase_settings` (and anything else gated on it) can never apply against a branch ref. Reported in #345.

## What is the new behavior?

On 404 from `GET /v1/projects/{ref}`, `waitForProjectActive` falls back to `GET /v1/branches/{branch_id_or_ref}` (`V1GetABranchConfigWithResponse`). `BranchDetailResponse.Status` shares the project status vocabulary (`ACTIVE_HEALTHY`, `COMING_UP`, `INIT_FAILED`, …), so it feeds the existing state machine unchanged — including fail-fast on terminal states and polling on transient ones. Refs unknown to both endpoints still fail with the original error, so the race #272 fixed (#239) stays fixed for real projects.

Tests:
- Unit tests for the fallback: active branch, transient→active polling, terminal branch state, ref unknown to both endpoints.
- Acceptance test `TestAccSettingsResource_BranchRef` mocking the full 404→branches-endpoint flow for both create and update of `supabase_settings`.

## Additional context

The status vocabulary trap for anyone touching this later: the branches **list** endpoint (`GET /v1/projects/{ref}/branches`) reports a workflow-style `status` (`FUNCTIONS_DEPLOYED`, …) plus a separate `preview_project_status`; only the branch **detail** endpoint used here reports project-style status directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
