### PR TITLE
docs: document the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          # Pin the release version to the tag that triggered this workflow,
+          # in case the commit is referenced by multiple tags.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
   publish:
     needs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,9 +55,14 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
+  # Keep the release as a draft; the `publish` job in the release workflow
+  # takes it live after manual approval.
   draft: true
-  replace_existing_draft: true
+  # If a draft release was already created from the GitHub UI (its title must
+  # match the tag name), attach artifacts to it instead of replacing it, and
+  # preserve its release notes.
+  use_existing_draft: true
+  mode: keep-existing
 changelog:
   use: github
   groups:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,14 @@ make testacc
 
 Releasing requires maintainer permissions, and nothing goes live until a manual approval at the very end.
 
-1. Draft a new release on the [GitHub releases page](https://github.com/supabase/terraform-provider-supabase/releases/new): choose a new tag following [semantic versioning](https://semver.org/) (e.g., `v1.10.0`), click **Generate release notes**, and edit the notes as needed. Keep the release title identical to the tag name (GoReleaser locates the draft by its title), then click **Save draft**.
-1. Saving a draft does _not_ create the git tag, so create and push it yourself:
+1. Create a draft release with a new tag following [semantic versioning](https://semver.org/) (e.g., `v1.10.0`) and auto-generated release notes:
+
+   ```shell
+   gh release create v1.10.0 --draft --generate-notes
+   ```
+
+   Edit the notes as needed via the link the command prints (or `gh release edit`). You can also draft the release from the [GitHub releases page](https://github.com/supabase/terraform-provider-supabase/releases/new) instead — if you do, keep the release title identical to the tag name, since GoReleaser locates the draft by its title.
+1. Drafting a release does _not_ create the git tag, so create and push it yourself:
 
    ```shell
    git tag v1.10.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,20 +61,20 @@ make testacc
 
 ## Releasing the Provider
 
-Releases are driven by git tags and require maintainer permissions. To cut a release, tag the tip of `main` with a new version following [semantic versioning](https://semver.org/) and push it:
+Releasing requires maintainer permissions, and nothing goes live until a manual approval at the very end.
 
-```shell
-git tag v1.10.0
-git push origin v1.10.0
-```
+1. Draft a new release on the [GitHub releases page](https://github.com/supabase/terraform-provider-supabase/releases/new): choose a new tag following [semantic versioning](https://semver.org/) (e.g., `v1.10.0`), click **Generate release notes**, and edit the notes as needed. Keep the release title identical to the tag name (GoReleaser locates the draft by its title), then click **Save draft**.
+1. Saving a draft does _not_ create the git tag, so create and push it yourself:
 
-Pushing the tag triggers the [release workflow](.github/workflows/release.yml), which:
+   ```shell
+   git tag v1.10.0
+   git push origin v1.10.0
+   ```
 
-1. Builds and signs binaries for all supported platforms via [GoReleaser](https://goreleaser.com/), then creates a draft GitHub release with the binaries attached and a changelog generated from merged PR titles.
-1. Waits for manual approval from a maintainer (under the workflow run's `publish` job).
-1. Once approved, publishes the release. The [Terraform Registry](https://registry.terraform.io/providers/supabase/supabase/latest) picks up the new version automatically.
+1. Pushing the tag triggers the [release workflow](.github/workflows/release.yml): [GoReleaser](https://goreleaser.com/) builds and signs binaries for all supported platforms and attaches them to your draft, leaving your release notes untouched. (Step 1 is optional — if no draft exists, GoReleaser creates one with an auto-generated changelog.)
+1. Review the draft release, then approve the workflow's `publish` job. This publishes the release, and the [Terraform Registry](https://registry.terraform.io/providers/supabase/supabase/latest) picks up the new version automatically.
 
 ### Common pitfalls
 
-- **Prefer pushing a tag over creating a release in the GitHub UI.** The workflow is only triggered by a tag being pushed. Saving a draft release in the UI doesn't create the tag, so nothing happens; publishing one does create the tag, but the release then goes live before any binaries exist. Pushing the tag directly lets the workflow create the release, and it stays a draft until the binaries are built and approved.
-- **Each release needs its own fresh commit.** GoReleaser fails with a `422 already_exists` error when uploading assets if the tagged commit already carries a previously released tag (e.g., tagging `v1.10.0` on the same commit as an already-released `v1.10.0-alpha`). If the tip of `main` has already been released under another tag, land a new commit first (an empty commit via a PR works) and tag that.
+- **A draft release alone does nothing.** The workflow only triggers on a tag push, and GitHub doesn't create the tag until a release is published — hence step 2. Conversely, avoid the **Publish release** button: it also creates the tag, but takes the release live before any binaries exist.
+- **Tagging a commit that already carries a released tag.** The workflow pins GoReleaser to the pushed tag (`GORELEASER_CURRENT_TAG`), so this should work, but if the release still fails with `422 already_exists` errors while uploading assets, land a new commit (an empty commit via a PR works) and tag that instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,23 @@ _Note:_ Acceptance tests create real resources, and often cost money to run.
 ```shell
 make testacc
 ```
+
+## Releasing the Provider
+
+Releases are driven by git tags and require maintainer permissions. To cut a release, tag the tip of `main` with a new version following [semantic versioning](https://semver.org/) and push it:
+
+```shell
+git tag v1.10.0
+git push origin v1.10.0
+```
+
+Pushing the tag triggers the [release workflow](.github/workflows/release.yml), which:
+
+1. Builds and signs binaries for all supported platforms via [GoReleaser](https://goreleaser.com/), then creates a draft GitHub release with the binaries attached and a changelog generated from merged PR titles.
+1. Waits for manual approval from a maintainer (under the workflow run's `publish` job).
+1. Once approved, publishes the release. The [Terraform Registry](https://registry.terraform.io/providers/supabase/supabase/latest) picks up the new version automatically.
+
+### Common pitfalls
+
+- **Prefer pushing a tag over creating a release in the GitHub UI.** The workflow is only triggered by a tag being pushed. Saving a draft release in the UI doesn't create the tag, so nothing happens; publishing one does create the tag, but the release then goes live before any binaries exist. Pushing the tag directly lets the workflow create the release, and it stays a draft until the binaries are built and approved.
+- **Each release needs its own fresh commit.** GoReleaser fails with a `422 already_exists` error when uploading assets if the tagged commit already carries a previously released tag (e.g., tagging `v1.10.0` on the same commit as an already-released `v1.10.0-alpha`). If the tip of `main` has already been released under another tag, land a new commit first (an empty commit via a PR works) and tag that.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation of the release process (previously undocumented), plus two small config tweaks that make the documented flow safe.

## What is the current behavior?

The release process is mostly internal, and the last release (`v1.10.x`) hit several gotchas:

- Saving a draft release does **not** create the git tag, so the `on: push: tags` workflow never triggers — but publishing from the UI takes the release live before any binaries exist.
- GoReleaser resolved the wrong version when the tagged commit already carried a previously released tag (`v1.10.0` on the same commit as `v1.10.0-alpha`), failing asset uploads with `422 already_exists`.
- `.goreleaser.yml` used `replace_existing_draft: true`, which **deletes** any manually drafted release (notes and all) before creating its own.

## What is the new behavior?

`CONTRIBUTING.md` documents the release flow:

1. `gh release create vX.Y.Z --draft --generate-notes` — draft the release and notes up front (creates no tag).
2. `git tag vX.Y.Z && git push origin vX.Y.Z` — triggers the release workflow.
3. GoReleaser builds/signs binaries and attaches them to the existing draft, preserving its notes.
4. A maintainer reviews the draft, then approves the `publish` job — only then does the release (and the Terraform Registry version) go live.

Config changes supporting it:

- `.goreleaser.yml`: `replace_existing_draft: true` → `use_existing_draft: true` + explicit `mode: keep-existing`, so a pre-drafted release is reused instead of overwritten.
- `.github/workflows/release.yml`: adds `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}`, pinning version resolution to the pushed tag (fixes the multi-tag `422` failure above).

## Additional context

Design decisions worth calling out:

- **Goals**: (1) the releaser keeps agency over the tag name and drafts the release notes themselves; (2) nothing is published until the manually approved `publish` step. This process could be streamlined further (e.g., pure tag-push with GoReleaser-generated notes and no pre-drafting), but we deliberately adhered to these goals.
- GoReleaser matches the existing draft **by title**, so the docs call out keeping the title identical to the tag name (`gh release create --generate-notes` does this automatically).
- Trade-off: with `use_existing_draft`, re-running a job that failed mid-upload can `422` on already-uploaded assets (the old setting was clean-slate). Escape hatch: delete the draft and re-run; setting `replace_existing_artifacts: true` would automate this if it becomes annoying.
- Verified against primary sources: `gh release edit` (the `publish` step) finds draft releases by pending tag via GraphQL, so un-drafting works; `use_existing_draft` requires GoReleaser ≥ v2.5 (the action installs latest v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
