### PR TITLE
feat: validate and trim SUPABASE_API_ENDPOINT

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -115,12 +115,27 @@ type retryGETTransport struct {
 }
 
 func (t *retryGETTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.Method == http.MethodGet {
-		return t.retrying.RoundTrip(req)
-	}
-	return t.plain.RoundTrip(req)
-}
+	var resp *http.Response
+	var err error
 
+	if req.Method == http.MethodGet {
+		resp, err = t.retrying.RoundTrip(req)
+	} else {
+		resp, err = t.plain.RoundTrip(req)
+	}
+
+	// If the request context was cancelled while the underlying transport
+	// returned a response, we must treat that as a cancellation and not
+	// return the response to callers. Close the body to avoid leaks.
+	if err == nil && req.Context().Err() != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		return nil, req.Context().Err()
+	}
+
+	return resp, err
+}
 func newRetryableClient(base *http.Client) *http.Client {
 	rc := retryablehttp.NewClient()
 	if base != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -197,7 +197,7 @@ func (p *SupabaseProvider) Configure(ctx context.Context, req provider.Configure
 	if apiEndpoint == "" {
 		apiEndpoint = defaultApiEndpoint
 	} else {
-        // Validate URL structure, scheme, and host
+		// Validate URL structure, scheme, and host
 		u, err := url.ParseRequestURI(apiEndpoint)
 		if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
 			resp.Diagnostics.AddAttributeError(

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,26 +116,10 @@ type retryGETTransport struct {
 }
 
 func (t *retryGETTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	var resp *http.Response
-	var err error
-
 	if req.Method == http.MethodGet {
-		resp, err = t.retrying.RoundTrip(req)
-	} else {
-		resp, err = t.plain.RoundTrip(req)
+		return t.retrying.RoundTrip(req)
 	}
-
-	// If the request context was cancelled while the underlying transport
-	// returned a response, we must treat that as a cancellation and not
-	// return the response to callers. Close the body to avoid leaks.
-	if err == nil && req.Context().Err() != nil {
-		if resp != nil && resp.Body != nil {
-			_ = resp.Body.Close()
-		}
-		return nil, req.Context().Err()
-	}
-
-	return resp, err
+	return t.plain.RoundTrip(req)
 }
 func newRetryableClient(base *http.Client) *http.Client {
 	rc := retryablehttp.NewClient()
@@ -206,21 +191,43 @@ func (p *SupabaseProvider) Configure(ctx context.Context, req provider.Configure
 		apiEndpoint = data.Endpoint.ValueString()
 	}
 
-	// Trim whitespace from the endpoint
+	// Save original endpoint to check for whitespace-only strings
+	originalEndpoint := apiEndpoint
 	apiEndpoint = strings.TrimSpace(apiEndpoint)
 
 	if apiEndpoint == "" {
-		apiEndpoint = defaultApiEndpoint
-	} else {
-		// Validate URL structure, scheme, and host
-		u, err := url.ParseRequestURI(apiEndpoint)
-		if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		if originalEndpoint != "" {
+			// The input was only whitespace, which is invalid
 			resp.Diagnostics.AddAttributeError(
 				path.Root("endpoint"),
 				"Invalid Supabase API Endpoint",
-				fmt.Sprintf("The endpoint %q is not a valid URL. It must be a fully-qualified HTTP/HTTPS URL, for example: https://api.supabase.com", apiEndpoint),
+				"The endpoint cannot be only whitespace.",
 			)
-			return
+		} else {
+			apiEndpoint = defaultApiEndpoint
+		}
+	} else {
+		// Validate URL structure, scheme, host, queries, fragments, and ports
+		u, err := url.Parse(apiEndpoint)
+		invalid := err != nil ||
+			(u.Scheme != "https" && u.Scheme != "http") ||
+			u.Hostname() == "" ||
+			u.RawQuery != "" || u.ForceQuery || u.Fragment != ""
+
+		if !invalid {
+			if portText := u.Port(); portText != "" {
+				port, portErr := strconv.Atoi(portText)
+				invalid = portErr != nil || port < 1 || port > 65535
+			}
+		}
+
+		if invalid {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("endpoint"),
+				"Invalid Supabase API Endpoint",
+				fmt.Sprintf("The endpoint %q is not a valid Supabase API endpoint. Use a fully-qualified HTTP or HTTPS URL with a hostname, no query or fragment, and, if specified, a port from 1 to 65535.", apiEndpoint),
+			)
+			// Intentionally not returning here so Terraform can also evaluate access_token errors below
 		}
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -212,7 +212,9 @@ func (p *SupabaseProvider) Configure(ctx context.Context, req provider.Configure
 		invalid := err != nil ||
 			(u.Scheme != "https" && u.Scheme != "http") ||
 			u.Hostname() == "" ||
-			u.RawQuery != "" || u.ForceQuery || u.Fragment != ""
+			u.RawQuery != "" || u.ForceQuery ||
+			strings.Contains(apiEndpoint, "#") ||
+			strings.HasSuffix(u.Host, ":")
 
 		if !invalid {
 			if portText := u.Port(); portText != "" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -5,7 +5,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -188,8 +190,23 @@ func (p *SupabaseProvider) Configure(ctx context.Context, req provider.Configure
 	if !data.Endpoint.IsNull() {
 		apiEndpoint = data.Endpoint.ValueString()
 	}
+
+	// Trim whitespace from the endpoint
+	apiEndpoint = strings.TrimSpace(apiEndpoint)
+
 	if apiEndpoint == "" {
 		apiEndpoint = defaultApiEndpoint
+	} else {
+		// Validate URL structure and scheme
+		u, err := url.ParseRequestURI(apiEndpoint)
+		if err != nil || (u.Scheme != "https" && u.Scheme != "http") {
+			resp.Diagnostics.AddAttributeError(
+				path.Root("endpoint"),
+				"Invalid Supabase API Endpoint",
+				fmt.Sprintf("The endpoint %q is not a valid URL. It must be a fully-qualified HTTP/HTTPS URL, for example: https://api.supabase.com", apiEndpoint),
+			)
+			return
+		}
 	}
 
 	// Validate access_token

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -197,9 +197,9 @@ func (p *SupabaseProvider) Configure(ctx context.Context, req provider.Configure
 	if apiEndpoint == "" {
 		apiEndpoint = defaultApiEndpoint
 	} else {
-		// Validate URL structure and scheme
+        // Validate URL structure, scheme, and host
 		u, err := url.ParseRequestURI(apiEndpoint)
-		if err != nil || (u.Scheme != "https" && u.Scheme != "http") {
+		if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("endpoint"),
 				"Invalid Supabase API Endpoint",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -326,8 +326,15 @@ data "supabase_branch" "test" {
 func TestAccProviderConfigure_EndpointValidation_Invalid(t *testing.T) {
 	// Verify that invalid endpoints trigger a diagnostic error and halt execution.
 	invalidEndpoints := []string{
-		"api.supabase.com",          // Missing scheme
-		"http:////api.supabase.com", // Malformed
+		"api.supabase.com",                          // Missing scheme
+		"http:////api.supabase.com",                 // Malformed
+		"ftp://api.supabase.com",                    // Unsupported scheme
+		"https://:443",                              // Port without hostname
+		"https://localhost:99999",                   // Port out of range
+		"https://gateway.example/supabase?tenant=x", // Query component
+		"https://gateway.example/supabase?",         // Empty query component
+		"https://gateway.example/supabase#frag",     // Fragment component
+		"   ",                                       // Whitespace-only endpoint
 	}
 
 	for _, endpoint := range invalidEndpoints {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -334,6 +334,8 @@ func TestAccProviderConfigure_EndpointValidation_Invalid(t *testing.T) {
 		"https://gateway.example/supabase?tenant=x", // Query component
 		"https://gateway.example/supabase?",         // Empty query component
 		"https://gateway.example/supabase#frag",     // Fragment component
+		"https://gateway.example/supabase#",         // Empty fragment
+		"https://selfhosted.example.com:",           // Empty explicit port
 		"   ",                                       // Whitespace-only endpoint
 	}
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -322,3 +322,62 @@ data "supabase_branch" "test" {
 		},
 	})
 }
+
+func TestAccProviderConfigure_EndpointValidation_Invalid(t *testing.T) {
+	// Verify that invalid endpoints trigger a diagnostic error and halt execution.
+	invalidEndpoints := []string{
+		"api.supabase.com",          // Missing scheme
+		"http:////api.supabase.com", // Malformed
+	}
+
+	for _, endpoint := range invalidEndpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck: func() {
+					testAccPreCheck(t)
+					t.Setenv("SUPABASE_API_ENDPOINT", endpoint)
+					t.Setenv("SUPABASE_ACCESS_TOKEN", "test-token")
+				},
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: fmt.Sprintf(`
+data "supabase_branch" "test" {
+  parent_project_ref = "%s"
+}
+`, testProjectRef),
+						ExpectError: regexp.MustCompile("Invalid Supabase API Endpoint"),
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccProviderConfigure_EndpointValidation_Trimmed(t *testing.T) {
+	// Verify that endpoints with accidental whitespace are successfully trimmed and used.
+	defer gock.OffAll()
+	gock.New("https://api.supabase.com").
+		Get(branchesApiPath).
+		Persist().
+		Reply(http.StatusOK).
+		JSON([]map[string]any{})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			t.Setenv("SUPABASE_API_ENDPOINT", "  https://api.supabase.com  ")
+			t.Setenv("SUPABASE_ACCESS_TOKEN", "test-token")
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "supabase_branch" "test" {
+  parent_project_ref = "%s"
+}
+`, testProjectRef),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## What does this PR do?
This PR adds validation and whitespace trimming to the `endpoint` configuration and `SUPABASE_API_ENDPOINT` environment variable during provider configuration. 

## Why is this necessary?
Previously, if a user accidentally included a trailing space in their environment variable (e.g., `export SUPABASE_API_ENDPOINT="https://api.supabase.com "`) or provided a malformed URL without a scheme, the raw string was passed directly to the HTTP client. This resulted in cryptic, low-level network errors during `terraform plan` or `apply`. 

By validating the endpoint upfront using `net/url`, we can catch human error instantly and return a helpful, actionable Terraform Diagnostic error.

## Changes
* Added `strings.TrimSpace` to the resolved `apiEndpoint`.
* Added `url.ParseRequestURI` validation to ensure the endpoint has a valid structure and an `http`/`https` scheme.
* Emits an explicit `AddAttributeError` diagnostic if validation fails.
* Added table-driven acceptance tests in `provider_test.go` to prove invalid inputs are caught and padded inputs are trimmed successfully.

## Demo / Terminal Output

**Before this PR (Cryptic Network Error):**
`Error: querying branches: Get "api.supabase.com/v1/projects/...": unsupported protocol scheme ""`

**After this PR (Clear Diagnostic Error):**
`Error: Invalid Supabase API Endpoint`

  `with provider["registry.terraform.io/supabase/supabase"],`
  `on main.tf line 1, in provider "supabase":`
   `1: provider "supabase" {`

`The endpoint "api.supabase.com" is not a valid URL. It must be a fully-qualified HTTP/HTTPS URL, for example: https://api.supabase.com`