### PR TITLE
fix(settings): forward every postgres parameter in database settings

### DIFF
--- a/internal/provider/settings_resource.go
+++ b/internal/provider/settings_resource.go
@@ -463,11 +463,12 @@ func readDatabaseConfig(ctx context.Context, state *SettingsResourceModel, clien
 	case http.StatusNotFound, http.StatusNotAcceptable:
 		return nil
 	}
-	if httpResp.JSON200 == nil {
-		msg := fmt.Sprintf("Unable to read database settings, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
+	config, err := decodeDatabaseConfig(httpResp.StatusCode(), httpResp.Body)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to read database settings, %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-	if state.Database, err = parseConfig(state.Database, *httpResp.JSON200); err != nil {
+	if state.Database, err = parseConfig(state.Database, config); err != nil {
 		msg := fmt.Sprintf("Unable to read database settings, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
@@ -475,26 +476,48 @@ func readDatabaseConfig(ctx context.Context, state *SettingsResourceModel, clien
 }
 
 func updateDatabaseConfig(ctx context.Context, plan *SettingsResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
-	var body api.UpdatePostgresConfigBody
+	// Only validate that the plan is a JSON object; the document itself is
+	// forwarded untouched so every parameter the API accepts reaches it.
+	var body map[string]any
 	if diags := plan.Database.Unmarshal(&body); diags.HasError() {
 		return diags
 	}
 
-	httpResp, err := client.V1UpdatePostgresConfigWithResponse(ctx, plan.ProjectRef.ValueString(), body)
+	httpResp, err := client.V1UpdatePostgresConfigWithBodyWithResponse(ctx, plan.ProjectRef.ValueString(), "application/json", strings.NewReader(plan.Database.ValueString()))
 	if err != nil {
 		msg := fmt.Sprintf("Unable to update database settings, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
-	if httpResp.JSON200 == nil {
-		msg := fmt.Sprintf("Unable to update database settings, got status %d: %s", httpResp.StatusCode(), httpResp.Body)
+	config, err := decodeDatabaseConfig(httpResp.StatusCode(), httpResp.Body)
+	if err != nil {
+		msg := fmt.Sprintf("Unable to update database settings, %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 
-	if plan.Database, err = parseConfig(plan.Database, *httpResp.JSON200); err != nil {
+	if plan.Database, err = parseConfig(plan.Database, config); err != nil {
 		msg := fmt.Sprintf("Unable to update database settings, got error: %s", err)
 		return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 	}
 	return nil
+}
+
+// decodeDatabaseConfig decodes a postgres config API response as a generic JSON
+// object instead of the generated api.PostgresConfigResponse struct.
+//
+// The generated request and response structs only know the parameters that
+// existed when the API client was generated, and encoding/json silently drops
+// every other key. Decoding the plan through api.UpdatePostgresConfigBody used
+// to strip newer parameters such as log_connections from the PUT body, so the
+// apply reported success while the API replaced the config without them.
+func decodeDatabaseConfig(statusCode int, body []byte) (map[string]any, error) {
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("got status %d: %s", statusCode, body)
+	}
+	var config map[string]any
+	if err := json.Unmarshal(body, &config); err != nil {
+		return nil, fmt.Errorf("got error: %w", err)
+	}
+	return config, nil
 }
 
 func readSslEnforcementConfig(ctx context.Context, state *SettingsResourceModel, client *api.ClientWithResponses) diag.Diagnostics {
@@ -600,7 +623,17 @@ func parseConfig(field jsontypes.Normalized, config any) (jsontypes.Normalized, 
 	return jsontypes.NewNormalizedValue(string(value)), nil
 }
 
+// requestOnlyConfigKeys are accepted by update endpoints but never returned by
+// the API, so they are preserved from the plan instead of being refreshed.
+var requestOnlyConfigKeys = map[string]bool{
+	"restart_database": true,
+}
+
 func pickConfig(source any, target map[string]any) {
+	if sourceMap, ok := source.(map[string]any); ok {
+		pickConfigMap(sourceMap, target)
+		return
+	}
 	v := reflect.ValueOf(source)
 	t := reflect.TypeOf(source)
 	for i := 0; i < v.NumField(); i++ {
@@ -639,7 +672,28 @@ func pickConfig(source any, target map[string]any) {
 	}
 }
 
+// pickConfigMap refreshes the user-managed keys in target from a generic API
+// response. A key the API no longer returns becomes null so that the removal
+// shows up as drift in the plan, mirroring how nil pointer fields of the
+// generated structs are handled.
+func pickConfigMap(source, target map[string]any) {
+	for k := range target {
+		if requestOnlyConfigKeys[k] {
+			continue
+		}
+		target[k] = source[k]
+	}
+}
+
 func copyConfig(source any, target map[string]any) {
+	if sourceMap, ok := source.(map[string]any); ok {
+		for k, v := range sourceMap {
+			if v != nil {
+				target[k] = v
+			}
+		}
+		return
+	}
 	v := reflect.ValueOf(source)
 	t := reflect.TypeOf(source)
 	for i := 0; i < v.NumField(); i++ {

--- a/internal/provider/settings_resource.go
+++ b/internal/provider/settings_resource.go
@@ -482,6 +482,9 @@ func updateDatabaseConfig(ctx context.Context, plan *SettingsResourceModel, clie
 	if diags := plan.Database.Unmarshal(&body); diags.HasError() {
 		return diags
 	}
+	if body == nil {
+		return diag.Diagnostics{diag.NewErrorDiagnostic("Invalid Attribute Value", "Database settings must be a JSON object, got null.")}
+	}
 
 	httpResp, err := client.V1UpdatePostgresConfigWithBodyWithResponse(ctx, plan.ProjectRef.ValueString(), "application/json", strings.NewReader(plan.Database.ValueString()))
 	if err != nil {
@@ -516,6 +519,9 @@ func decodeDatabaseConfig(statusCode int, body []byte) (map[string]any, error) {
 	var config map[string]any
 	if err := json.Unmarshal(body, &config); err != nil {
 		return nil, fmt.Errorf("got error: %w", err)
+	}
+	if config == nil {
+		return nil, fmt.Errorf("got error: expected a JSON object, got null")
 	}
 	return config, nil
 }

--- a/internal/provider/settings_resource_test.go
+++ b/internal/provider/settings_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -1229,6 +1230,149 @@ func TestParseConfigNullablePreservesUserValue(t *testing.T) {
 	if resultMap["external_apple_additional_client_ids"] != "com.example.app" {
 		t.Errorf("expected external_apple_additional_client_ids to be preserved as 'com.example.app', got %v",
 			resultMap["external_apple_additional_client_ids"])
+	}
+}
+
+// Every postgres parameter in the plan must reach the API, including ones the
+// generated API client does not know about such as log_connections. The old
+// typed decoding silently dropped them, so the apply succeeded while the API
+// replaced the config without them.
+func TestAccSettingsResource_DatabaseForwardsAllParameters(t *testing.T) {
+	defer gock.OffAll()
+
+	databaseConfig := fmt.Sprintf(`
+resource "supabase_settings" "test" {
+  project_ref = %q
+
+  database = jsonencode({
+    log_connections    = true
+    log_disconnections = true
+    statement_timeout  = "10s"
+  })
+}
+`, testProjectRef)
+	applied := map[string]any{
+		"log_connections":    true,
+		"log_disconnections": true,
+		"statement_timeout":  "10s",
+	}
+
+	gock.New(defaultApiEndpoint).
+		Get(projectApiPath).
+		Reply(http.StatusOK).
+		JSON(api.V1ProjectWithDatabaseResponse{
+			Id:     testProjectRef,
+			Status: api.V1ProjectWithDatabaseResponseStatusACTIVEHEALTHY,
+		})
+	mockServicesActiveHealth()
+	gock.New(defaultApiEndpoint).
+		Put(dbConfigApiPath).
+		AddMatcher(matchJSONBody(t, applied)).
+		Reply(http.StatusOK).
+		JSON(applied)
+	// Post-apply refresh.
+	gock.New(defaultApiEndpoint).
+		Get(dbConfigApiPath).
+		Reply(http.StatusOK).
+		JSON(applied)
+
+	// Connection logging is then disabled outside Terraform; the refresh must
+	// pick that up even though the generated client cannot decode the field.
+	gock.New(defaultApiEndpoint).
+		Get(dbConfigApiPath).
+		Persist().
+		Reply(http.StatusOK).
+		JSON(map[string]any{
+			"log_connections":   false,
+			"statement_timeout": "10s",
+		})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: databaseConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("supabase_settings.test", "id", testProjectRef),
+					resource.TestCheckResourceAttrWith("supabase_settings.test", "database", func(value string) error {
+						var database map[string]any
+						if err := json.Unmarshal([]byte(value), &database); err != nil {
+							return err
+						}
+						if !reflect.DeepEqual(database, applied) {
+							return fmt.Errorf("expected database settings %v in state, got %v", applied, database)
+						}
+						return nil
+					}),
+				),
+			},
+			{
+				Config:             databaseConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestParseConfigGenericResponse(t *testing.T) {
+	userConfig := `{
+		"log_connections": true,
+		"log_disconnections": true,
+		"statement_timeout": "10s",
+		"restart_database": true
+	}`
+	apiResponse := map[string]any{
+		"log_connections":   false,
+		"statement_timeout": "10s",
+		"max_connections":   float64(100),
+	}
+
+	result, err := parseConfig(jsontypes.NewNormalizedValue(userConfig), apiResponse)
+	if err != nil {
+		t.Fatalf("parseConfig failed: %v", err)
+	}
+
+	var resultMap map[string]any
+	if err := json.Unmarshal([]byte(result.ValueString()), &resultMap); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	expected := map[string]any{
+		// Refreshed from the API so out-of-band changes show up as drift.
+		"log_connections": false,
+		// Removed out-of-band: becomes null rather than keeping the stale value.
+		"log_disconnections": nil,
+		"statement_timeout":  "10s",
+		// Request-only flag the API never echoes back: preserved from the plan.
+		"restart_database": true,
+		// Keys not managed in the plan are ignored.
+	}
+	if !reflect.DeepEqual(resultMap, expected) {
+		t.Errorf("expected %v, got %v", expected, resultMap)
+	}
+}
+
+func TestParseConfigGenericResponseWithoutState(t *testing.T) {
+	apiResponse := map[string]any{
+		"log_connections": true,
+		"work_mem":        nil,
+	}
+
+	result, err := parseConfig(jsontypes.NewNormalizedNull(), apiResponse)
+	if err != nil {
+		t.Fatalf("parseConfig failed: %v", err)
+	}
+
+	var resultMap map[string]any
+	if err := json.Unmarshal([]byte(result.ValueString()), &resultMap); err != nil {
+		t.Fatalf("failed to unmarshal result: %v", err)
+	}
+
+	expected := map[string]any{"log_connections": true}
+	if !reflect.DeepEqual(resultMap, expected) {
+		t.Errorf("expected %v, got %v", expected, resultMap)
 	}
 }
 

--- a/internal/provider/settings_resource_test.go
+++ b/internal/provider/settings_resource_test.go
@@ -1316,6 +1316,65 @@ resource "supabase_settings" "test" {
 	})
 }
 
+// A null database document must be rejected before anything is sent. The old
+// typed decoding turned it into {} and wiped the project's postgres config.
+func TestAccSettingsResource_DatabaseRejectsNull(t *testing.T) {
+	defer gock.OffAll()
+
+	gock.New(defaultApiEndpoint).
+		Get(projectApiPath).
+		Reply(http.StatusOK).
+		JSON(api.V1ProjectWithDatabaseResponse{
+			Id:     testProjectRef,
+			Status: api.V1ProjectWithDatabaseResponseStatusACTIVEHEALTHY,
+		})
+	mockServicesActiveHealth()
+	putCalled := false
+	gock.New(defaultApiEndpoint).
+		Put(dbConfigApiPath).
+		AddMatcher(func(*http.Request, *gock.Request) (bool, error) {
+			putCalled = true
+			return true, nil
+		}).
+		Reply(http.StatusBadRequest)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "supabase_settings" "test" {
+  project_ref = %q
+  database    = jsonencode(null)
+}
+`, testProjectRef),
+				ExpectError: regexp.MustCompile(`must be a JSON object`),
+			},
+		},
+	})
+	if putCalled {
+		t.Error("database PUT was called with a null document")
+	}
+}
+
+func TestDecodeDatabaseConfig(t *testing.T) {
+	if _, err := decodeDatabaseConfig(http.StatusBadRequest, []byte(`{"message":"bad request"}`)); err == nil {
+		t.Error("expected an error for a non-200 status")
+	}
+	// A null body would otherwise null out every managed key in state.
+	if _, err := decodeDatabaseConfig(http.StatusOK, []byte(`null`)); err == nil {
+		t.Error("expected an error for a null body")
+	}
+	config, err := decodeDatabaseConfig(http.StatusOK, []byte(`{"log_connections":true}`))
+	if err != nil {
+		t.Fatalf("decodeDatabaseConfig failed: %v", err)
+	}
+	if config["log_connections"] != true {
+		t.Errorf("expected log_connections to be true, got %v", config["log_connections"])
+	}
+}
+
 func TestParseConfigGenericResponse(t *testing.T) {
 	userConfig := `{
 		"log_connections": true,


### PR DESCRIPTION
## Summary

The `database` block of `supabase_settings` was decoded into the generated `api.UpdatePostgresConfigBody` struct before being sent. That struct only knows the parameters that existed when the pinned API client (`github.com/supabase/cli/pkg v1.2.3`) was generated, and `encoding/json` silently drops every other key. Parameters such as `log_connections` and `log_disconnections` therefore never reached the API. Because the update endpoint replaces the whole postgres config, `terraform apply` reported success while the project ended up without those parameters, and the refresh could not surface the drift either.

## Changes

- `updateDatabaseConfig` validates that the plan is a JSON object and forwards the document to the API untouched via the raw-body client method, so every parameter the API accepts reaches it. Unknown keys now surface as a 400 from the API instead of a silent no-op.
- `readDatabaseConfig` and the update response are decoded as generic JSON objects, so newer parameters are refreshed and out-of-band removal shows up as drift (the key becomes `null`, mirroring how nil pointer fields of the generated structs were handled).
- Request-only keys (`restart_database`) are preserved from the plan since the API never echoes them back.
- `parseConfig`/`pickConfig`/`copyConfig` accept a `map[string]any` source alongside the existing struct reflection path used by the other settings blocks.

## Context

The pinned Go client cannot be bumped: the module has had no release since April and now lives under `apps/cli-go/pkg` in the CLI repo with its old module path, so Go rejects it. Regenerating a provider-owned client from the OpenAPI spec is a separate, larger follow-up that also affects the other settings blocks; this change fixes the database block independently of the client's age.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ee9BeCP1iRczrA7CPNtsV5