### PR TITLE
fix: tolerate 403 when reading legacy api keys during refresh

### DIFF
--- a/internal/provider/project_resource.go
+++ b/internal/provider/project_resource.go
@@ -345,7 +345,14 @@ func readProject(ctx context.Context, data *ProjectResourceModel, client *api.Cl
 
 	if legacyKeysResp.JSON200 == nil {
 		// This API endpoint will be removed in the future, so explicitly check for HTTP 404 Not Found.
-		if legacyKeysResp.StatusCode() != http.StatusNotFound {
+		// 403 Forbidden means the same thing from the caller's side — the legacy keys cannot be read for
+		// this project — and the Management API declares it as an expected response for this operation.
+		// Failing the refresh there takes down every other resource in the plan, so degrade instead.
+		switch legacyKeysResp.StatusCode() {
+		case http.StatusNotFound:
+		case http.StatusForbidden:
+			tflog.Warn(ctx, fmt.Sprintf("legacy api keys are not readable for project %s (403); assuming disabled", project.Id))
+		default:
 			msg := fmt.Sprintf("Unable to read project legacy api keys, got status %d: %s", legacyKeysResp.StatusCode(), legacyKeysResp.Body)
 			return diag.Diagnostics{diag.NewErrorDiagnostic("Client Error", msg)}
 		}

--- a/internal/provider/project_resource_test.go
+++ b/internal/provider/project_resource_test.go
@@ -509,3 +509,64 @@ func TestAccProjectResource_Timeouts(t *testing.T) {
 		},
 	})
 }
+
+func TestReadProject_LegacyApiKeysUnreadable(t *testing.T) {
+	// The legacy api keys endpoint is on its way out: Supabase answers 404 once it is gone for a
+	// project, and 403 for projects whose legacy keys the caller cannot read. Neither should fail
+	// the whole refresh — anything else still should.
+	for _, tt := range []struct {
+		name      string
+		status    int
+		wantError bool
+	}{
+		{name: "gone", status: http.StatusNotFound},
+		{name: "forbidden", status: http.StatusForbidden},
+		{name: "server error", status: http.StatusInternalServerError, wantError: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			defer gock.OffAll()
+			gock.InterceptClient(http.DefaultClient)
+			defer gock.RestoreClient(http.DefaultClient)
+
+			gock.New(defaultApiEndpoint).
+				Get(projectApiPath).
+				Reply(http.StatusOK).
+				JSON(api.V1ProjectWithDatabaseResponse{
+					Id:             testProjectRef,
+					Name:           "foo",
+					OrganizationId: "continued-brown-smelt",
+					Region:         "us-east-1",
+					Status:         api.V1ProjectWithDatabaseResponseStatusACTIVEHEALTHY,
+				})
+			gock.New(defaultApiEndpoint).
+				Get(legacyApiKeysApiPath).
+				Reply(tt.status).
+				JSON(map[string]string{"message": "nope"})
+			gock.New(defaultApiEndpoint).
+				Get(billingApiPath).
+				Reply(http.StatusOK).
+				JSON(api.ListProjectAddonsResponse{})
+
+			client, err := api.NewClientWithResponses(defaultApiEndpoint)
+			if err != nil {
+				t.Fatalf("Failed to create client: %v", err)
+			}
+
+			data := ProjectResourceModel{Id: types.StringValue(testProjectRef)}
+			diags := readProject(t.Context(), &data, client)
+
+			if tt.wantError {
+				if !diags.HasError() {
+					t.Fatalf("expected an error for status %d, got success", tt.status)
+				}
+				return
+			}
+			if diags.HasError() {
+				t.Fatalf("expected status %d to be tolerated, got: %v", tt.status, diags.Errors())
+			}
+			if data.LegacyApiKeysEnabled.ValueBool() {
+				t.Errorf("expected legacy_api_keys_enabled=false, got true")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`readProject` calls `V1GetProjectLegacyApiKeys` on every refresh and tolerates only `404`:

https://github.com/supabase/terraform-provider-supabase/blob/main/internal/provider/project_resource.go#L345-L353

The Management API also answers **403** for that operation. It is one of the declared responses on `GET /v1/projects/{ref}/api-keys/legacy` in the published spec (`https://api.supabase.com/api/v1-json`), alongside `200`, `401` and `429`:

```
PATH /v1/projects/{ref}/api-keys/legacy
  GET Check whether JWT based legacy (anon, service_role) API keys are enabled.
      This API endpoint will be removed in the future, check for HTTP 404 Not Found.
      | responses: ['200', '401', '403', '429']
```

When a project answers 403, the diagnostic aborts the entire refresh:

```
Error: Client Error

  with module.project.supabase_project.this,
  on modules/project/main.tf line 1, in resource "supabase_project" "this":
   1: resource "supabase_project" "this" {

Unable to read project legacy api keys, got status 403: {"message":"Your
account does not have the necessary privileges to access this endpoint. For
more details, refer to our documentation
https://supabase.com/docs/guides/platform/access-control"}
```

`terraform plan` then fails for **every** resource in the configuration — in our case `supabase_settings` never gets refreshed at all — over an attribute that is already deprecated and scheduled for removal.

We hit this on exactly one project out of nineteen in the same organisation, planned with the same access token. The nineteen that work were all created before the one that 403s, which is consistent with the endpoint being retired per-project rather than with an org-level permission problem — but either way the caller cannot read the value, which is the same situation `404` already covers.

## Change

Treat `403` the same as `404` in the **read** path: fall back to `legacy_api_keys_enabled = false` and emit a `tflog.Warn`. Any other status still errors as before.

The write path (`updateLegacyAPIKeysEnabled`) is deliberately unchanged — a 403 there is a real failure to act on something the user explicitly configured, and should surface.

## Test

Adds `TestReadProject_LegacyApiKeysUnreadable`, a table test over the legacy-keys status code:

| status | expectation |
|---|---|
| 404 | tolerated, `legacy_api_keys_enabled = false` |
| 403 | tolerated, `legacy_api_keys_enabled = false` |
| 500 | still an error |

It fails on `main` and passes with the fix:

```
$ git stash -- internal/provider/project_resource.go
$ go test ./internal/provider/ -run TestReadProject_LegacyApiKeysUnreadable
--- FAIL: TestReadProject_LegacyApiKeysUnreadable/forbidden
    project_resource_test.go:565: expected status 403 to be tolerated, got:
      [{Unable to read project legacy api keys, got status 403: ...}]
FAIL

$ git stash pop && go test ./internal/provider/ -run TestReadProject_LegacyApiKeysUnreadable
ok      github.com/supabase/terraform-provider-supabase/internal/provider   0.354s
```

`go vet ./...` and the full `go test ./...` are green.